### PR TITLE
fix(functions): delete Firebase Auth record after 2-year archive window

### DIFF
--- a/docs/DATA_RETENTION.md
+++ b/docs/DATA_RETENTION.md
@@ -51,11 +51,13 @@ A scheduled Cloud Function (`runDataLifecycleManagement`) will be configured to 
 
 ### Stage 2: Deletion (Cloud Storage -> Permanent Deletion)
 
-The final deletion of archived data will be handled automatically by **Google Cloud Storage Object Lifecycle Management**. This is the most efficient and cost-effective method for managing the final stage of the data's lifecycle.
+The final deletion of the archived **data file** is handled automatically by **Google Cloud Storage Object Lifecycle Management**. This is the most efficient and cost-effective method for managing the final stage of the data's lifecycle.
 
 *   **Configuration:**
     *   A lifecycle rule will be configured on the `getspot-archive/` path within our GCS bucket.
     *   **Action:** `Delete`
     *   **Condition:** The rule will be triggered when an object's **age** is greater than **730 days** (2 years).
 
-This two-stage approach separates the logic of *what* to archive (the Cloud Function) from the policy of *when* to permanently delete (GCS Lifecycle Management), creating a clean and robust system.
+GCS Lifecycle Management can only delete the storage object — it has no way to call the Firebase Authentication Admin SDK. For **User Accounts** specifically, the daily `runDataLifecycleManagement` job also runs `deleteExpiredArchivedUsers()`, which checks the same 730-day age threshold on each `archive/users/{uid}.json` object and calls `admin.auth().deleteUser(uid)` once it's passed. This is what actually removes the user's Firebase Authentication record; without it, the Auth record would persist indefinitely even after the archive file and Firestore data are gone.
+
+This two-stage approach separates the logic of *what* to archive (the Cloud Function) from the policy of *when* to permanently delete (GCS Lifecycle Management for the file, and the scheduled function for the Auth record), creating a clean and robust system.

--- a/functions/src/dataLifecycle.ts
+++ b/functions/src/dataLifecycle.ts
@@ -22,6 +22,7 @@ export const runDataLifecycleManagement = (db: admin.firestore.Firestore) => onS
       await archiveOldTransactions(db);
       await archiveInactiveGroups(db);
       await archiveInactiveUsers(db);
+      await deleteExpiredArchivedUsers();
       await deleteOldJoinRequests(db);
 
       functions.logger.info("Data lifecycle management job completed successfully.");
@@ -269,6 +270,52 @@ async function archiveInactiveUsers(db: admin.firestore.Firestore) {
   } while (pageToken);
 
   functions.logger.info(`Archived ${archivedCount} inactive users.`);
+}
+
+/**
+ * Deletes the Firebase Authentication record for users whose archived data
+ * has passed the 2-year retention window documented in DATA_RETENTION.md.
+ * GCS Object Lifecycle Management independently deletes the archive JSON
+ * file at the same age threshold, but it has no way to call the Firebase
+ * Auth Admin SDK — so this step is the only thing that removes the Auth
+ * record itself, which archiveInactiveUsers() never did.
+ * @return {Promise<void>} Resolves when the sweep completes.
+ */
+async function deleteExpiredArchivedUsers() {
+  functions.logger.info("Starting deleteExpiredArchivedUsers job.");
+  const bucket = admin.storage().bucket(ARCHIVE_BUCKET_NAME);
+  const auth = admin.auth();
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 730); // 2 years, matches the GCS lifecycle rule.
+
+  const [files] = await bucket.getFiles({prefix: "archive/users/"});
+
+  let deletedCount = 0;
+  for (const file of files) {
+    const [metadata] = await file.getMetadata();
+    const timeCreated = metadata.timeCreated ? new Date(metadata.timeCreated) : null;
+    if (!timeCreated || timeCreated >= cutoff) continue;
+
+    const match = file.name.match(/^archive\/users\/(.+)\.json$/);
+    if (!match) continue;
+    const userId = match[1];
+
+    try {
+      await auth.deleteUser(userId);
+      functions.logger.info(`Deleted expired Auth record for archived user ${userId}.`);
+      deletedCount++;
+    } catch (error) {
+      const authError = error as {code?: string};
+      if (authError.code === "auth/user-not-found") {
+        functions.logger.info(`Auth record for ${userId} was already gone; skipping.`);
+      } else {
+        functions.logger.error(`Error deleting Auth record for ${userId}:`, error);
+      }
+    }
+  }
+
+  functions.logger.info(`Deleted ${deletedCount} expired archived-user Auth records.`);
 }
 
 /**


### PR DESCRIPTION
archiveInactiveUsers() removed a user's Firestore data and GCS-archived it, but never deleted the Firebase Authentication record, so Auth accounts accumulated indefinitely. GCS Object Lifecycle Management can delete the archive file after 730 days but can't call the Auth Admin SDK, so nothing ever removed the Auth record on the documented 2-year timeline.

Add deleteExpiredArchivedUsers(), run daily alongside the existing lifecycle job, which checks each archive/users/{uid}.json object's age against the same 730-day cutoff and deletes the Auth record once passed. Update DATA_RETENTION.md to describe the two-part deletion (GCS Lifecycle for the file, this function for the Auth record).

Fixes #45