### PR TITLE
fix(app): handle duplicate join requests and web share fallback gracefully

### DIFF
--- a/lib/screens/group_details_screen.dart
+++ b/lib/screens/group_details_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:getspot/screens/create_event_screen.dart';
@@ -112,25 +113,26 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen>
       return;
     }
 
+    // Create the deep link URL
+    final deepLink = 'https://app.getspot.org/join/$code';
+
+    // Build share message
+    final StringBuffer messageBuffer = StringBuffer();
+    messageBuffer.writeln('Join our group on GetSpot!');
+    messageBuffer.writeln();
+    if (name != null && name.isNotEmpty) {
+      messageBuffer.writeln('Group: $name');
+    }
+    if (description != null && description.isNotEmpty) {
+      messageBuffer.writeln(description);
+    }
+    messageBuffer.writeln();
+    messageBuffer.writeln('Tap to join: $deepLink');
+    messageBuffer.writeln();
+    messageBuffer.writeln('Or use code: $code in the GetSpot app');
+    final String message = messageBuffer.toString();
+
     try {
-      // Create the deep link URL
-      final deepLink = 'https://app.getspot.org/join/$code';
-
-      // Build share message
-      final StringBuffer message = StringBuffer();
-      message.writeln('Join our group on GetSpot!');
-      message.writeln();
-      if (name != null && name.isNotEmpty) {
-        message.writeln('Group: $name');
-      }
-      if (description != null && description.isNotEmpty) {
-        message.writeln(description);
-      }
-      message.writeln();
-      message.writeln('Tap to join: $deepLink');
-      message.writeln();
-      message.writeln('Or use code: $code in the GetSpot app');
-
       // Get the share button position for iPad popover
       final box = context.findRenderObject() as RenderBox?;
       final sharePositionOrigin = box != null
@@ -139,7 +141,7 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen>
 
       await SharePlus.instance.share(
         ShareParams(
-          text: message.toString(),
+          text: message,
           subject: 'Join ${name ?? "our group"} on GetSpot',
           sharePositionOrigin: sharePositionOrigin,
         ),
@@ -148,7 +150,20 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen>
       developer.log('Group shared successfully', name: 'GroupDetailsScreen');
     } catch (e) {
       developer.log('Error sharing group', name: 'GroupDetailsScreen', error: e);
-      if (mounted) {
+      if (!mounted) return;
+
+      if (kIsWeb) {
+        // The Web Share API isn't available in every browser (e.g. Firefox,
+        // or non-HTTPS/localhost contexts), so fall back to copying the
+        // invite text instead of just showing an error.
+        await Clipboard.setData(ClipboardData(text: message));
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Sharing isn\'t supported in this browser. Invite message copied to clipboard instead.'),
+          ),
+        );
+      } else {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
             content: Text('Error sharing: ${e.toString()}'),

--- a/lib/screens/join_group_screen.dart
+++ b/lib/screens/join_group_screen.dart
@@ -20,6 +20,7 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
   String? _errorMessage;
   QueryDocumentSnapshot<Map<String, dynamic>>? _foundGroup;
   bool _isAlreadyMember = false;
+  String? _existingRequestStatus;
 
   @override
   void initState() {
@@ -33,6 +34,7 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
       _errorMessage = null;
       _foundGroup = null;
       _isAlreadyMember = false;
+      _existingRequestStatus = null;
     });
 
     try {
@@ -57,12 +59,17 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
       } else {
         final foundGroup = groupQuery.docs.first;
         final isAlreadyMember = await _checkMembership(foundGroup.id);
+        final existingRequestStatus = isAlreadyMember
+            ? null
+            : await _checkExistingRequest(foundGroup.id);
         setState(() {
           _foundGroup = foundGroup;
           _isAlreadyMember = isAlreadyMember;
+          _existingRequestStatus = existingRequestStatus;
         });
         developer.log(
-          'Found group: ${foundGroup.data()['name']} (alreadyMember: $isAlreadyMember)',
+          'Found group: ${foundGroup.data()['name']} '
+          '(alreadyMember: $isAlreadyMember, existingRequestStatus: $existingRequestStatus)',
           name: 'JoinGroupScreen',
         );
       }
@@ -95,6 +102,27 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
         .get();
 
     return membershipDoc.exists;
+  }
+
+  /// Returns the `status` of the user's existing join request for this group
+  /// (e.g. `'pending'`, `'denied'`), or null if none exists. Firestore
+  /// Security Rules only allow a user to `create` a join request, not
+  /// `update` one — writing over an existing request throws
+  /// permission-denied, so we must check for one up front and steer the UI
+  /// accordingly rather than let that write fail.
+  Future<String?> _checkExistingRequest(String groupId) async {
+    final user = FirebaseAuth.instance.currentUser;
+    if (user == null) return null;
+
+    final requestDoc = await FirebaseFirestore.instance
+        .collection('groups')
+        .doc(groupId)
+        .collection('joinRequests')
+        .doc(user.uid)
+        .get();
+
+    if (!requestDoc.exists) return null;
+    return requestDoc.data()?['status'] as String? ?? 'pending';
   }
 
   void _goToGroup() {
@@ -145,12 +173,30 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
     } catch (e) {
       developer.log('Error sending join request', name: 'JoinGroupScreen', error: e);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(e.toString()),
-            backgroundColor: Theme.of(context).colorScheme.error,
-          ),
-        );
+        // Security Rules only allow creating a join request, not overwriting
+        // one — a permission-denied here almost always means a request from
+        // this user already exists (e.g. a race with another tab, or this
+        // screen's own pre-check was stale). Re-check and show a friendly
+        // message instead of the raw Firestore error.
+        final isPermissionDenied = e is FirebaseException && e.code == 'permission-denied';
+        final status = isPermissionDenied
+            ? await _checkExistingRequest(_foundGroup!.id)
+            : null;
+        if (mounted) {
+          setState(() {
+            _existingRequestStatus = status;
+          });
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text(
+                status != null
+                    ? 'You already have a request to join this group ($status).'
+                    : e.toString(),
+              ),
+              backgroundColor: Theme.of(context).colorScheme.error,
+            ),
+          );
+        }
       }
     } finally {
       if (mounted) {
@@ -265,6 +311,28 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
                 ),
               ],
             ),
+          ] else if (_existingRequestStatus == 'pending') ...[
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Icon(Icons.hourglass_top, color: Colors.orange.shade700, size: 20),
+                const SizedBox(width: 8),
+                const Expanded(
+                  child: Text('Your request to join this group is pending approval.'),
+                ),
+              ],
+            ),
+          ] else if (_existingRequestStatus != null) ...[
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                Icon(Icons.info_outline, color: Colors.grey.shade600, size: 20),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text('Your previous request was $_existingRequestStatus. Contact the group admin for help.'),
+                ),
+              ],
+            ),
           ],
           const Spacer(),
           SizedBox(
@@ -272,7 +340,9 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
             child: ElevatedButton(
               onPressed: _isLoading
                   ? null
-                  : (_isAlreadyMember ? _goToGroup : _sendJoinRequest),
+                  : (_isAlreadyMember
+                      ? _goToGroup
+                      : (_existingRequestStatus != null ? null : _sendJoinRequest)),
               style: ElevatedButton.styleFrom(
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 backgroundColor: Theme.of(context).primaryColor,
@@ -288,7 +358,11 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
                       ),
                     )
                   : Text(
-                      _isAlreadyMember ? 'Go to Group' : 'Request to Join',
+                      _isAlreadyMember
+                          ? 'Go to Group'
+                          : (_existingRequestStatus == 'pending'
+                              ? 'Request Pending'
+                              : (_existingRequestStatus != null ? 'Request $_existingRequestStatus' : 'Request to Join')),
                       style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
                     ),
             ),


### PR DESCRIPTION
## Summary
- Fix bug where re-requesting to join a group (after an initial pending request) threw a raw Firestore `permission-denied` error instead of a friendly message — Security Rules only allow creating a `joinRequests` doc, not overwriting one, so `join_group_screen.dart` now checks for an existing request up front, disables/relabels the button, and shows its status ("pending"/"denied") instead of attempting a doomed write. A `permission-denied` on the write itself is also caught and translated, covering races.
- Add a clipboard fallback for the group share button on web (`group_details_screen.dart`) — the Web Share API isn't supported in every browser (e.g. Firefox, or non-HTTPS/localhost), so a failed share now copies the invite text and tells the user, instead of surfacing a raw error.

## Test plan
- [x] `flutter analyze` clean on both changed files
- [ ] Manually verify: request to join a group, then immediately retry — should show "Request Pending" (disabled) instead of an error
- [ ] Manually verify on web: trigger group share in a browser without Web Share API support (e.g. Firefox) — invite text should be copied to clipboard with a confirmation snackbar