### PR TITLE
ci: add OSV-Scanner and dependency review workflows

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,29 @@
+# Flags pull requests that introduce a dependency with a known vulnerability
+# or a disallowed license, using GitHub's own dependency graph diff. Runs at
+# PR time so it catches issues before merge, complementing Dependabot's
+# alerts (which only fire after landing on the default branch).
+# https://github.com/actions/dependency-review-action
+
+name: Dependency review
+
+on:
+  pull_request:
+    branches:
+      - main
+      - develop
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          comment-summary-in-pr: always

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,48 @@
+# CodeQL's default setup only covers JS/TS + GitHub Actions, so it doesn't
+# scan the Flutter/Dart app code or Python tests. OSV-Scanner fills that gap
+# by checking pubspec.lock, package-lock.json, and requirements.txt/similar
+# against the OSV vulnerability database, and uploads findings to the
+# Security > Code scanning tab like CodeQL does.
+#
+# This workflow uses actions that are not certified by GitHub. They are
+# provided by a third-party (Google) and are governed by separate terms of
+# service, privacy policy, and support documentation.
+# https://google.github.io/osv-scanner/github-action/
+
+name: OSV-Scanner
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+  schedule:
+    - cron: '0 8 * * 1' # Weekly, Monday 08:00 UTC
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  contents: read
+
+jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67" # v2.5.1
+    with:
+      scan-args: |-
+        -r
+        --skip-git
+        ./
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@6e4298ebc4db23e847df9b2e2de2939d6f066c67" # v2.5.1
+    with:
+      scan-args: |-
+        -r
+        --skip-git
+        ./


### PR DESCRIPTION
## Summary
- Add `osv-scanner.yml` — runs Google's OSV-Scanner against lockfiles (`pubspec.lock`, `functions/package-lock.json`, `tests/` deps, etc.) on push/PR to `main`/`develop` and weekly on schedule, uploading results to the Security > Code scanning tab. Closes the gap left by CodeQL's default setup, which only covers JS/TS + GitHub Actions and has no support for Dart, so the Flutter app code currently has no vulnerability scanning at all.
- Add `dependency-review.yml` — runs GitHub's native Dependency Review action on PRs targeting `main`/`develop`, flagging any newly-introduced dependency with a known vulnerability directly in the PR, before merge (complements Dependabot's alerts, which only fire after landing on the default branch).
- Both are free, first/second-party GitHub Actions features with no signup required, appropriate for a public repo.

## Test plan
- [x] YAML validated (`python -c "import yaml; yaml.safe_load(...)"`) for both files
- [ ] Confirm both workflows run successfully once merged/opened as a PR (OSV-Scanner PR check + scheduled scan, Dependency Review comment on this PR)
- [ ] Check Security > Code scanning tab after first scheduled OSV-Scanner run to confirm SARIF upload works