### PR TITLE
fix(ci): grant actions:read permission to OSV-Scanner workflow

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -25,6 +25,10 @@ on:
   workflow_dispatch:
 
 permissions:
+  # actions: read is required by the reusable workflows below to upload the
+  # SARIF file to code scanning. See:
+  # https://github.com/github/codeql-action/issues/2117
+  actions: read
   security-events: write
   contents: read
 


### PR DESCRIPTION
## Summary
- Fixes the OSV-Scanner workflow added in #98, which fails at startup (`startup_failure`, zero jobs created) as soon as it's exercised on a PR: https://github.com/amitrke/getspot/actions/runs/32654166159
- Root cause: the reusable workflows it calls (`osv-scanner-reusable.yml` / `osv-scanner-reusable-pr.yml`) require `actions: read` internally to upload their SARIF file to code scanning. When a caller doesn't grant a permission scope a reusable workflow's job requests, GitHub refuses to start the run at all instead of failing a specific step — hence no jobs ever appeared. Added `actions: read` alongside the existing `contents: read` / `security-events: write`.

## Test plan
- [x] YAML validated
- [ ] Confirm this PR's own OSV-Scanner check now runs (has jobs) and completes instead of hitting `startup_failure`