### PR TITLE
fix(ci): stop OSV-Scanner PR-diff scanning against main

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -17,8 +17,13 @@ on:
       - main
       - develop
   pull_request:
+    # Diff-scanning PRs into main would run `git checkout main` inside the
+    # reusable workflow, which is ambiguous in this repo because of the
+    # top-level main/ directory ("'main' could be both a local file and a
+    # tracking branch") and fails the job. Not a coverage gap: a develop -> main
+    # PR was already diff-scanned as a feature branch's PR into develop, and
+    # gets scanned again post-merge via the push trigger above.
     branches:
-      - main
       - develop
   schedule:
     - cron: '0 8 * * 1' # Weekly, Monday 08:00 UTC


### PR DESCRIPTION
## Summary
- Fixes the OSV-Scanner failure on PR #99 (`develop` -> `main`): https://github.com/amitrke/getspot/actions/runs/32654321741
- The `scan-pr` job's reusable workflow runs a bare `git checkout $GITHUB_BASE_REF`. For a PR based on `main`, that's `git checkout main` — ambiguous in this repo because of the top-level `main/` directory (the Next.js site), so git refuses with `'main' could be both a local file and a tracking branch` and the job fails (exit 128), leaving an empty `results.sarif` and cascading upload failures.
- Restricted the `pull_request` trigger to `develop` only. No coverage lost: a `develop` -> `main` release PR's commits were already diff-scanned as feature-branch PRs into `develop`, and get scanned again post-merge via the existing `push` trigger to `main`.

## Test plan
- [x] YAML validated
- [ ] Confirm PR #99 (or the next `develop` -> `main` PR) no longer triggers a failing OSV-Scanner PR check