### PR TITLE
feat(main): expand first FAQ item by default

### DIFF
--- a/main/src/app/faq/page.tsx
+++ b/main/src/app/faq/page.tsx
@@ -80,8 +80,8 @@ export default function FaqPage() {
         </div>
 
         <div className="mt-16 divide-y divide-zinc-200 dark:divide-zinc-800">
-          {faqs.map((faq) => (
-            <details key={faq.question} className="group py-5">
+          {faqs.map((faq, index) => (
+            <details key={faq.question} open={index === 0} className="group py-5">
               <summary className="flex cursor-pointer list-none items-center justify-between text-left text-sm font-semibold">
                 {faq.question}
                 <span className="ml-4 shrink-0 text-zinc-400 transition-transform group-open:rotate-45">


### PR DESCRIPTION
## Summary
- Opens the first FAQ item by default on the marketing site's FAQ page so a visitor sees a real answer immediately, instead of a page of collapsed questions with nothing showing.
- Keeps the accordion pattern for the rest — better for scannability across all ten questions than expanding everything.

## Test plan
- [x] `npm run lint` clean in `main/`
- [ ] Visually confirm on `npm run dev` that the first item renders open and the rest remain collapsed/toggleable