### PR TITLE
feat(app): require email verification before app access

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:getspot/firebase_options.dart';
 import 'package:getspot/screens/home_screen.dart';
 import 'package:getspot/screens/login_screen.dart';
+import 'package:getspot/screens/verify_email_screen.dart';
 import 'package:getspot/screens/event_details_screen.dart';
 import 'package:getspot/screens/group_details_screen.dart';
 import 'dart:developer' as developer;
@@ -363,6 +364,16 @@ class _AuthWrapperState extends State<AuthWrapper> {
 
         // User is logged in
         if (user != null) {
+          // Email/password accounts must verify their address before
+          // reaching the app; Google/Apple sign-in already asserts a
+          // verified email. userChanges() fires on reload(), so once the
+          // user verifies and taps "I've verified" this swaps to
+          // HomeScreen automatically.
+          if (!user.emailVerified) {
+            developer.log('Showing VerifyEmailScreen for user: ${user.uid}', name: 'AuthWrapper');
+            return const VerifyEmailScreen();
+          }
+
           developer.log('Showing HomeScreen for user: ${user.uid}', name: 'AuthWrapper');
           // Set analytics user ID
           _analytics.setUserId(user.uid);

--- a/lib/screens/verify_email_screen.dart
+++ b/lib/screens/verify_email_screen.dart
@@ -1,0 +1,154 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:getspot/services/auth_service.dart';
+import 'dart:developer' as developer;
+
+/// Shown by [AuthWrapper] instead of [HomeScreen] whenever a signed-in
+/// user's email/password account has not verified its email address, so
+/// no part of the app is reachable until they do (or they sign out).
+class VerifyEmailScreen extends StatefulWidget {
+  const VerifyEmailScreen({super.key});
+
+  @override
+  State<VerifyEmailScreen> createState() => _VerifyEmailScreenState();
+}
+
+class _VerifyEmailScreenState extends State<VerifyEmailScreen> {
+  final AuthService _authService = AuthService();
+  bool _isChecking = false;
+  bool _isResending = false;
+  DateTime? _lastResendAt;
+
+  Future<void> _checkVerified() async {
+    setState(() {
+      _isChecking = true;
+    });
+    try {
+      await FirebaseAuth.instance.currentUser?.reload();
+      // AuthWrapper listens on userChanges(), which fires on reload(), so
+      // it will automatically swap to HomeScreen once this flips to true.
+      if (mounted && FirebaseAuth.instance.currentUser?.emailVerified != true) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Still not verified. Check your inbox (and spam folder) for the link.'),
+          ),
+        );
+      }
+    } catch (e) {
+      developer.log('Error checking verification status', name: 'VerifyEmailScreen', error: e);
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isChecking = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _resendEmail() async {
+    if (_lastResendAt != null &&
+        DateTime.now().difference(_lastResendAt!) < const Duration(seconds: 60)) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Please wait a bit before requesting another email.')),
+      );
+      return;
+    }
+
+    setState(() {
+      _isResending = true;
+    });
+    try {
+      await FirebaseAuth.instance.currentUser?.sendEmailVerification();
+      _lastResendAt = DateTime.now();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Verification email sent. Check your inbox.')),
+        );
+      }
+    } on FirebaseAuthException catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.message ?? 'Could not send verification email.'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isResending = false;
+        });
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final email = FirebaseAuth.instance.currentUser?.email ?? 'your email';
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(maxWidth: 480),
+            child: Padding(
+              padding: const EdgeInsets.all(24.0),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(
+                    Icons.mark_email_unread_outlined,
+                    size: 72,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    'Verify your email',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                    textAlign: TextAlign.center,
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    'We sent a verification link to $email. Click it, then come back and tap '
+                    '"I\'ve verified my email" below.',
+                    textAlign: TextAlign.center,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 32),
+                  ElevatedButton(
+                    onPressed: _isChecking ? null : _checkVerified,
+                    style: ElevatedButton.styleFrom(minimumSize: const Size(double.infinity, 48)),
+                    child: _isChecking
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('I\'ve verified my email'),
+                  ),
+                  const SizedBox(height: 12),
+                  OutlinedButton(
+                    onPressed: _isResending ? null : _resendEmail,
+                    style: OutlinedButton.styleFrom(minimumSize: const Size(double.infinity, 48)),
+                    child: _isResending
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Text('Resend verification email'),
+                  ),
+                  const SizedBox(height: 12),
+                  TextButton(
+                    onPressed: () => _authService.signOut(),
+                    child: const Text('Sign out'),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -246,6 +246,17 @@ class AuthService {
           'email': email,
           'createdAt': FieldValue.serverTimestamp(),
         });
+
+        // Send the verification email. Don't fail the signup if this
+        // errors — the user can still request another one from the
+        // verify-email screen.
+        try {
+          await updatedUser.sendEmailVerification();
+        } catch (e) {
+          developer.log('Error sending verification email: $e',
+              name: 'AuthService');
+        }
+
         return userCredential;
       }
       return null;


### PR DESCRIPTION
## Summary
- Previously, `createUserWithEmailAndPassword` never confirmed the requester actually controlled the email they signed up with — anyone could register under an address they didn't own, and that unverified `displayName`/`email` would then be visible to other group members via `users/{uid}`.
- `signUpWithEmailAndPassword` now sends a verification email right after account creation (best-effort — signup doesn't fail if the send errors).
- `AuthWrapper` (`main.dart`) now gates `HomeScreen` behind `user.emailVerified`. Google/Apple sign-in already asserts a verified email, so those flows are unaffected — this only applies to the email/password path.
- New `VerifyEmailScreen`: shown instead of the app when unverified, with "I've verified my email" (reloads the user — `userChanges()` fires on reload, so it swaps to `HomeScreen` automatically once true), "Resend verification email" (60s client-side cooldown), and "Sign out".

## Heads up
This check runs on every session, not just new signups. Any existing user who registered via email/password before this change and never verified will hit the verify-email screen on their next app open. It's not a permanent lockout (they can resend + verify), but it is a behavior change for existing accounts, not just new ones — flagging in case that warrants a heads-up to users or a grandfathering exception.

## Test plan
- [x] `flutter analyze` clean (no new issues; pre-existing infos unrelated to this change)
- [x] `flutter build web --release` succeeds
- [ ] Manually verify: sign up with email/password → land on VerifyEmailScreen → click emailed link → tap "I've verified my email" → auto-lands on HomeScreen
- [ ] Manually verify: "Resend verification email" works and respects the cooldown
- [ ] Manually verify: Google/Apple sign-in is unaffected (goes straight to HomeScreen)