### PR TITLE
fix(app): stop web sign-out from hanging forever

### DIFF
--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -304,12 +304,21 @@ class AuthService {
       // Clear crashlytics user ID
       await _crashlytics.clearUserId();
 
-      // Sign out from Google first
-      await _googleSignIn.signOut();
-
-      // Disconnect Google account to ensure fresh sign-in next time
-      // In v7.x, we can safely call disconnect without checking
+      // On web, signInWithGoogle() never calls _initializeGoogleSignIn() —
+      // it signs in via Firebase's signInWithPopup directly instead, so
+      // _googleSignIn (the GoogleSignIn.instance singleton) is never
+      // initialized regardless of how the user signed in. Calling
+      // .signOut()/.disconnect() on it awaits an internal Completer that
+      // only ever completes inside .initialize() — on web that hangs this
+      // method forever instead of throwing, silently breaking the sign-out
+      // button. Skip both entirely on web; there's no google_sign_in
+      // session to clear there anyway.
       if (!kIsWeb) {
+        // Sign out from Google first
+        await _googleSignIn.signOut();
+
+        // Disconnect Google account to ensure fresh sign-in next time
+        // In v7.x, we can safely call disconnect without checking
         try {
           await _googleSignIn.disconnect();
         } catch (e) {


### PR DESCRIPTION
## Summary
- `signInWithGoogle()` on web never calls `_initializeGoogleSignIn()` — it signs in via Firebase's `signInWithPopup` directly instead, so the `GoogleSignIn.instance` singleton is never initialized on web, regardless of whether the user signed in with Google, Apple, or email/password.
- `signOut()` unconditionally called `_googleSignIn.signOut()`. Per the `google_sign_in_web` package source, that awaits an internal `Completer` that only ever completes inside `.initialize()` — on web that `await` never resolves, so it silently hangs `signOut()` forever instead of throwing. The caller's subsequent navigation to `LoginScreen` (in `member_profile_screen.dart`) never runs — the sign-out button appears to do nothing, for every web user.
- Extends the existing `if (!kIsWeb)` guard (already applied to `.disconnect()`, for the identical reason) to also cover `.signOut()`. There's no `google_sign_in` package session to clear on web anyway.

## Test plan
- [x] `flutter analyze` clean (no new issues)
- [ ] Manually verify: sign in on web (any method), tap sign-out, confirm it now navigates back to the login screen immediately instead of doing nothing