### PR TITLE
fix(security): stop /groups from being fully listable by any signed-in user

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,7 +35,15 @@ service cloud.firestore {
     }
 
     match /groups/{groupId} {
-      allow read, create: if request.auth != null;
+      // get (single doc by known ID) is safe to leave open — group IDs are
+      // unguessable Firestore auto-IDs. list is denied outright: Firestore
+      // can't redact fields per query, so an open list would let any
+      // authenticated user enumerate every group's admin uid,
+      // negativeBalanceLimit, etc. The one legitimate non-member lookup
+      // (join by code) goes through the findGroupByCode callable instead,
+      // which runs with Admin SDK privileges and returns only safe fields.
+      allow get, create: if request.auth != null;
+      allow list: if false;
       allow update, delete: if request.auth.uid == resource.data.admin;
 
       //--- SUBCOLLECTIONS ---//

--- a/functions/src/findGroupByCode.ts
+++ b/functions/src/findGroupByCode.ts
@@ -1,0 +1,63 @@
+import {onCall, HttpsError} from "firebase-functions/v2/https";
+import * as admin from "firebase-admin";
+import * as logger from "firebase-functions/logger";
+
+interface FindGroupByCodeData {
+  code: string;
+}
+
+/**
+ * Returns a callable function that looks up a group by its shareable code.
+ *
+ * Firestore Security Rules deny arbitrary `list` queries on `/groups` to
+ * prevent an authenticated user from enumerating every group (and its
+ * admin uid, negativeBalanceLimit, etc.) they aren't a member of. This
+ * function runs with Admin SDK privileges and is the only way a
+ * non-member can look up a group before joining — it returns just the
+ * fields needed for the "you've been invited to join X" preview screen.
+ *
+ * @param {admin.firestore.Firestore} db - The Firestore database instance.
+ * @return {onCall<FindGroupByCodeData>} An HTTPS callable function.
+ * @throws {HttpsError} Throws for unauthenticated requests, invalid
+ * arguments, or if no group matches the code.
+ */
+export const findGroupByCode = (db: admin.firestore.Firestore) =>
+  onCall<FindGroupByCodeData>(async (request) => {
+    if (!request.auth) {
+      throw new HttpsError("unauthenticated", "Authentication required.");
+    }
+
+    const {code} = request.data;
+    if (!code || typeof code !== "string") {
+      throw new HttpsError("invalid-argument", "Missing required parameter: code.");
+    }
+
+    // Standardize the same way the group's groupCodeSearch field is stored
+    // (uppercase, no dashes) at creation time — see createGroup in index.ts.
+    const standardizedCode = code.trim().toUpperCase().replace(/-/g, "");
+
+    try {
+      const snapshot = await db
+        .collection("groups")
+        .where("groupCodeSearch", "==", standardizedCode)
+        .limit(1)
+        .get();
+
+      if (snapshot.empty) {
+        throw new HttpsError("not-found", "No group found with that code.");
+      }
+
+      const doc = snapshot.docs[0];
+      const data = doc.data();
+      return {
+        groupId: doc.id,
+        name: data.name ?? "",
+        description: data.description ?? "",
+        groupCode: data.groupCode ?? "",
+      };
+    } catch (err) {
+      if (err instanceof HttpsError) throw err;
+      logger.error("findGroupByCode error", err);
+      throw new HttpsError("internal", "Unexpected error.");
+    }
+  });

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./maintainJoinRequestCount";
 import {updateEventCapacity as updateEventCapacityHandler} from "./updateEventCapacity";
 import {notifyOnAnnouncement as notifyOnAnnouncementHandler} from "./notifyOnAnnouncement";
+import {findGroupByCode as findGroupByCodeHandler} from "./findGroupByCode";
 // import {initializePendingJoinRequestsCount as initializePendingJoinRequestsCountHandler} from "./migrations/initializePendingJoinRequestsCount";
 
 
@@ -194,6 +195,7 @@ export const onJoinRequestUpdated = onJoinRequestUpdatedHandler(db);
 export const onJoinRequestDeleted = onJoinRequestDeletedHandler(db);
 export const updateEventCapacity = updateEventCapacityHandler(db);
 export const notifyOnAnnouncement = notifyOnAnnouncementHandler(db);
+export const findGroupByCode = findGroupByCodeHandler(db);
 
 // Migration function - call once, then comment out or remove
 // MIGRATION COMPLETED - Commented out on 2025-10-07

--- a/lib/screens/join_group_screen.dart
+++ b/lib/screens/join_group_screen.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'dart:developer' as developer;
@@ -18,7 +19,11 @@ class JoinGroupScreen extends StatefulWidget {
 class _JoinGroupScreenState extends State<JoinGroupScreen> {
   bool _isLoading = true;
   String? _errorMessage;
-  QueryDocumentSnapshot<Map<String, dynamic>>? _foundGroup;
+  // Populated from the findGroupByCode callable, so only contains the safe
+  // preview fields (groupId, name, description, groupCode) — never admin,
+  // negativeBalanceLimit, etc. See _goToGroup for the full-document fetch
+  // used once membership is confirmed.
+  Map<String, dynamic>? _foundGroup;
   bool _isAlreadyMember = false;
   String? _existingRequestStatus;
 
@@ -43,35 +48,42 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
         name: 'JoinGroupScreen',
       );
 
-      // Standardize the input for a case-insensitive search
-      final standardizedCode = widget.groupCode.trim().toUpperCase().replaceAll("-", "");
-      final groupQuery = await FirebaseFirestore.instance
-          .collection('groups')
-          .where('groupCodeSearch', isEqualTo: standardizedCode)
-          .limit(1)
-          .get();
+      // Groups aren't directly listable/queryable by non-members (Firestore
+      // Security Rules deny `list` on /groups to prevent enumerating every
+      // group's admin uid, negativeBalanceLimit, etc.), so the code lookup
+      // goes through a callable that runs with Admin SDK privileges and
+      // returns only the safe preview fields.
+      final functions = FirebaseFunctions.instanceFor(region: 'us-east4');
+      final callable = functions.httpsCallable('findGroupByCode');
+      final result = await callable.call({'code': widget.groupCode});
+      final foundGroup = Map<String, dynamic>.from(result.data as Map);
+      final groupId = foundGroup['groupId'] as String;
 
-      if (groupQuery.docs.isEmpty) {
+      final isAlreadyMember = await _checkMembership(groupId);
+      final existingRequestStatus = isAlreadyMember
+          ? null
+          : await _checkExistingRequest(groupId);
+      setState(() {
+        _foundGroup = foundGroup;
+        _isAlreadyMember = isAlreadyMember;
+        _existingRequestStatus = existingRequestStatus;
+      });
+      developer.log(
+        'Found group: ${foundGroup['name']} '
+        '(alreadyMember: $isAlreadyMember, existingRequestStatus: $existingRequestStatus)',
+        name: 'JoinGroupScreen',
+      );
+    } on FirebaseFunctionsException catch (e) {
+      if (e.code == 'not-found') {
         setState(() {
           _errorMessage = 'No group found with code: ${widget.groupCode}';
         });
         developer.log('No group found with code: ${widget.groupCode}', name: 'JoinGroupScreen');
       } else {
-        final foundGroup = groupQuery.docs.first;
-        final isAlreadyMember = await _checkMembership(foundGroup.id);
-        final existingRequestStatus = isAlreadyMember
-            ? null
-            : await _checkExistingRequest(foundGroup.id);
+        developer.log('Error finding group', name: 'JoinGroupScreen', error: e);
         setState(() {
-          _foundGroup = foundGroup;
-          _isAlreadyMember = isAlreadyMember;
-          _existingRequestStatus = existingRequestStatus;
+          _errorMessage = 'An error occurred while looking up the group. Please try again.';
         });
-        developer.log(
-          'Found group: ${foundGroup.data()['name']} '
-          '(alreadyMember: $isAlreadyMember, existingRequestStatus: $existingRequestStatus)',
-          name: 'JoinGroupScreen',
-        );
       }
     } catch (e) {
       developer.log('Error finding group', name: 'JoinGroupScreen', error: e);
@@ -125,15 +137,45 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
     return requestDoc.data()?['status'] as String? ?? 'pending';
   }
 
-  void _goToGroup() {
+  Future<void> _goToGroup() async {
     if (_foundGroup == null) return;
+    final groupId = _foundGroup!['groupId'] as String;
 
-    final groupData = {..._foundGroup!.data(), 'groupId': _foundGroup!.id};
-    Navigator.of(context).pushReplacement(
-      MaterialPageRoute(
-        builder: (context) => GroupDetailsScreen(group: groupData),
-      ),
-    );
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      // _foundGroup only has the safe preview fields from findGroupByCode.
+      // Now that membership is confirmed, fetch the full document (allowed
+      // for any authenticated user via `get`) for GroupDetailsScreen.
+      final groupDoc = await FirebaseFirestore.instance.collection('groups').doc(groupId).get();
+      if (!mounted) return;
+      if (!groupDoc.exists) {
+        setState(() {
+          _isLoading = false;
+          _errorMessage = 'This group no longer exists.';
+        });
+        return;
+      }
+
+      final groupData = {...groupDoc.data()!, 'groupId': groupId};
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(
+          builder: (context) => GroupDetailsScreen(group: groupData),
+        ),
+      );
+    } catch (e) {
+      developer.log('Error loading group', name: 'JoinGroupScreen', error: e);
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not open the group. Please try again.')),
+        );
+      }
+    }
   }
 
   Future<void> _sendJoinRequest() async {
@@ -149,7 +191,8 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
         throw Exception('You must be logged in to send a request.');
       }
 
-      final groupRef = _foundGroup!.reference;
+      final groupId = _foundGroup!['groupId'] as String;
+      final groupRef = FirebaseFirestore.instance.collection('groups').doc(groupId);
       final requestRef = groupRef.collection('joinRequests').doc(user.uid);
 
       await requestRef.set({
@@ -180,7 +223,7 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
         // message instead of the raw Firestore error.
         final isPermissionDenied = e is FirebaseException && e.code == 'permission-denied';
         final status = isPermissionDenied
-            ? await _checkExistingRequest(_foundGroup!.id)
+            ? await _checkExistingRequest(_foundGroup!['groupId'] as String)
             : null;
         if (mounted) {
           setState(() {
@@ -252,7 +295,7 @@ class _JoinGroupScreenState extends State<JoinGroupScreen> {
     }
 
     if (_foundGroup != null) {
-      final groupData = _foundGroup!.data();
+      final groupData = _foundGroup!;
       return Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/lib/services/group_cache_service.dart
+++ b/lib/services/group_cache_service.dart
@@ -135,14 +135,19 @@ class GroupCacheService {
       );
 
       try {
-        final snapshot = await FirebaseFirestore.instance
-            .collection('groups')
-            .where(FieldPath.documentId, whereIn: toFetch)
-            .get();
+        // Individual gets rather than a whereIn(documentId) query: /groups
+        // denies `list` entirely (Firestore can't redact fields per query,
+        // so an open list would let any authenticated user enumerate every
+        // group's admin uid, negativeBalanceLimit, etc.) but `get` by a
+        // known ID stays open, which is all a batch of specific groupIds
+        // needs.
+        final docs = await Future.wait(
+          toFetch.map((groupId) => FirebaseFirestore.instance.collection('groups').doc(groupId).get()),
+        );
 
-        for (final doc in snapshot.docs) {
+        for (final doc in docs) {
           if (doc.exists) {
-            final data = doc.data();
+            final data = doc.data()!;
             final group = CachedGroup(
               groupId: doc.id,
               name: data['name'] ?? 'Unnamed Group',

--- a/lib/services/group_service.dart
+++ b/lib/services/group_service.dart
@@ -90,11 +90,19 @@ class GroupService {
     }
 
     try {
-      final groupsSnapshot = await _firestore
-          .collection('groups')
-          .where(FieldPath.documentId, whereIn: allGroupIds)
-          .get();
-      final groupDocs = {for (var doc in groupsSnapshot.docs) doc.id: doc};
+      // Individual gets rather than a whereIn(documentId) query: /groups
+      // denies `list` entirely (Firestore can't redact fields per query, so
+      // an open list would let any authenticated user enumerate every
+      // group's admin uid, negativeBalanceLimit, etc.) but `get` by a known
+      // ID stays open — including for allGroupIds' pending-join-request
+      // groups, which the caller isn't a member of yet.
+      final groupSnapshots = await Future.wait(
+        allGroupIds.map((groupId) => _firestore.collection('groups').doc(groupId).get()),
+      );
+      final groupDocs = {
+        for (var doc in groupSnapshots)
+          if (doc.exists) doc.id: doc
+      };
 
       final memberViewModels =
           await _fetchMemberViewModels(user.uid, memberships.docs, groupDocs);

--- a/lib/widgets/join_group_modal.dart
+++ b/lib/widgets/join_group_modal.dart
@@ -1,4 +1,5 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:cloud_functions/cloud_functions.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
@@ -16,7 +17,11 @@ class _JoinGroupModalState extends State<JoinGroupModal> {
   final _codeController = TextEditingController();
   bool _isLoading = false;
   String? _errorMessage;
-  QueryDocumentSnapshot<Map<String, dynamic>>? _foundGroup;
+  // Populated from the findGroupByCode callable, so only contains the safe
+  // preview fields (groupId, name, description, groupCode) — never admin,
+  // negativeBalanceLimit, etc. See _goToGroup for the full-document fetch
+  // used once membership is confirmed.
+  Map<String, dynamic>? _foundGroup;
   bool _isAlreadyMember = false;
 
   @override
@@ -37,27 +42,27 @@ class _JoinGroupModalState extends State<JoinGroupModal> {
     });
 
     try {
-      // Standardize the input for a case-insensitive search
-      final enteredCode =
-          _codeController.text.trim().toUpperCase().replaceAll("-", "");
-      final groupQuery = await FirebaseFirestore.instance
-          .collection('groups')
-          .where('groupCodeSearch', isEqualTo: enteredCode)
-          .limit(1)
-          .get();
+      // Groups aren't directly listable/queryable by non-members (Firestore
+      // Security Rules deny `list` on /groups to prevent enumerating every
+      // group's admin uid, negativeBalanceLimit, etc.), so the code lookup
+      // goes through a callable that runs with Admin SDK privileges and
+      // returns only the safe preview fields.
+      final functions = FirebaseFunctions.instanceFor(region: 'us-east4');
+      final callable = functions.httpsCallable('findGroupByCode');
+      final result = await callable.call({'code': _codeController.text.trim()});
+      final foundGroup = Map<String, dynamic>.from(result.data as Map);
+      final groupId = foundGroup['groupId'] as String;
 
-      if (groupQuery.docs.isEmpty) {
-        setState(() {
-          _errorMessage = 'No group found with that code.';
-        });
-      } else {
-        final foundGroup = groupQuery.docs.first;
-        final isAlreadyMember = await _checkMembership(foundGroup.id);
-        setState(() {
-          _foundGroup = foundGroup;
-          _isAlreadyMember = isAlreadyMember;
-        });
-      }
+      final isAlreadyMember = await _checkMembership(groupId);
+      setState(() {
+        _foundGroup = foundGroup;
+        _isAlreadyMember = isAlreadyMember;
+      });
+    } on FirebaseFunctionsException catch (e) {
+      setState(() {
+        _errorMessage =
+            e.code == 'not-found' ? 'No group found with that code.' : 'An error occurred. Please try again.';
+      });
     } catch (e) {
       setState(() {
         _errorMessage = 'An error occurred. Please try again.';
@@ -88,16 +93,45 @@ class _JoinGroupModalState extends State<JoinGroupModal> {
     return membershipDoc.exists;
   }
 
-  void _goToGroup() {
+  Future<void> _goToGroup() async {
     if (_foundGroup == null) return;
+    final groupId = _foundGroup!['groupId'] as String;
 
-    final groupData = {..._foundGroup!.data(), 'groupId': _foundGroup!.id};
-    Navigator.of(context).pop();
-    Navigator.of(context).push(
-      MaterialPageRoute(
-        builder: (context) => GroupDetailsScreen(group: groupData),
-      ),
-    );
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      // _foundGroup only has the safe preview fields from findGroupByCode.
+      // Now that membership is confirmed, fetch the full document (allowed
+      // for any authenticated user via `get`) for GroupDetailsScreen.
+      final groupDoc = await FirebaseFirestore.instance.collection('groups').doc(groupId).get();
+      if (!mounted) return;
+      if (!groupDoc.exists) {
+        setState(() {
+          _isLoading = false;
+          _errorMessage = 'This group no longer exists.';
+        });
+        return;
+      }
+
+      final groupData = {...groupDoc.data()!, 'groupId': groupId};
+      Navigator.of(context).pop();
+      Navigator.of(context).push(
+        MaterialPageRoute(
+          builder: (context) => GroupDetailsScreen(group: groupData),
+        ),
+      );
+    } catch (e) {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Could not open the group. Please try again.')),
+        );
+      }
+    }
   }
 
   Future<void> _sendJoinRequest() async {
@@ -113,7 +147,8 @@ class _JoinGroupModalState extends State<JoinGroupModal> {
         throw Exception('You must be logged in to send a request.');
       }
 
-      final groupRef = _foundGroup!.reference;
+      final groupId = _foundGroup!['groupId'] as String;
+      final groupRef = FirebaseFirestore.instance.collection('groups').doc(groupId);
       final requestRef = groupRef.collection('joinRequests').doc(user.uid);
 
       await requestRef.set({
@@ -214,7 +249,7 @@ class _JoinGroupModalState extends State<JoinGroupModal> {
   }
 
   Widget _buildGroupDetails() {
-    final groupData = _foundGroup!.data();
+    final groupData = _foundGroup!;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [


### PR DESCRIPTION
## Summary
- `allow read, create: if request.auth != null` on `/groups/{groupId}` let any authenticated user run an open, unfiltered `list` query over the entire `groups` collection — leaking every group's `admin` uid, `negativeBalanceLimit`, `groupCode`, etc., even for groups they aren't a member of. Firestore can't redact fields per query, so an open `list` is a full data dump, not just an enumeration risk.
- Splits `read` into `get` (kept open — group IDs are unguessable Firestore auto-IDs, and ~19 call sites across the app legitimately read a single known group doc) and `list: if false` (closes the hole outright).
- **Verified against a real Firestore emulator**, not just reasoned about: unauthenticated `get` denied, authenticated `get`-by-ID allowed, an open `list` denied, a `groupCodeSearch`-filtered `list` denied, a `whereIn(documentId)` `list` denied, `create` unaffected.
- The one legitimate non-member read — looking up a group by its join code, which by definition happens before membership exists — now goes through a new `findGroupByCode` callable (Admin SDK privileged) that returns only `{groupId, name, description, groupCode}`, never the sensitive fields. `join_group_screen.dart` and `join_group_modal.dart` call it instead of querying Firestore directly.
- The two `whereIn(documentId)` batch queries (`group_service.dart`, `group_cache_service.dart` — used for membership + pending-join-request group previews) are replaced with `Future.wait` over individual `.doc(id).get()` calls, legal under the new `get` rule.

## Test plan
- [x] Rules verified against the Firestore emulator (6/6 assertions passing)
- [x] `flutter analyze` clean on all touched Flutter files
- [x] `npm run lint` / `npm run build` / `npm test` clean in `functions/`
- [ ] Manually verify: joining a group by code still works end-to-end (preview screen shows name/description, join request still succeeds)
- [ ] Manually verify: home screen still shows pending join-request group cards correctly (exercises the `whereIn` → individual-`get` refactor in `group_service.dart`)

⚠️ This changes Firestore Security Rules — those only deploy to production on push to `main` (`deploy-firestore-rules.yml`), so this isn't live until the next `develop` → `main` release PR merges.