### PR TITLE
feat(app): let members leave a group themselves

### DIFF
--- a/functions/src/manageGroupMember.ts
+++ b/functions/src/manageGroupMember.ts
@@ -5,7 +5,7 @@ import * as logger from "firebase-functions/logger";
 interface ManageGroupMemberData {
   groupId: string;
   targetUserId: string;
-  action: "remove" | "credit";
+  action: "remove" | "credit" | "leave";
   amount?: number; // required for credit
   description?: string; // optional note for credit
 }
@@ -24,12 +24,15 @@ interface MemberDoc {
 /**
  * Returns a callable function for managing existing group members.
  *
- * This function supports two primary actions, determined by the `action` parameter
+ * This function supports three actions, determined by the `action` parameter
  * in the request data:
- *  - `remove`: Deletes a member from a group and removes their corresponding
- *    entry from the `userGroupMemberships` collection. This action has
- *    preconditions: the member cannot be the group admin and must have a
- *    wallet balance of zero.
+ *  - `remove`: Admin-only. Deletes a member from a group and removes their
+ *    corresponding entry from the `userGroupMemberships` collection. Has
+ *    preconditions: the member cannot be the group admin, must have a
+ *    wallet balance of zero, and cannot have a confirmed/waitlisted
+ *    registration for any upcoming active event in the group.
+ *  - `leave`: Self-service equivalent of `remove` — a member removes
+ *    themselves, with the same preconditions.
  *  - `credit`: Adds a specified amount to a member's wallet balance and creates
  *    a corresponding transaction record in the `transactions` collection.
  *
@@ -65,20 +68,48 @@ export const manageGroupMember = (db: admin.firestore.Firestore) =>
         throw new HttpsError("not-found", "Group not found.");
       }
       const groupData = groupSnap.data() as GroupDoc | undefined;
-      if (!groupData || groupData.admin !== callerUid) {
+      if (!groupData) {
+        throw new HttpsError("not-found", "Group not found.");
+      }
+
+      if (action === "leave") {
+        if (callerUid !== targetUserId) {
+          throw new HttpsError(
+            "permission-denied",
+            "You can only remove yourself with the leave action."
+          );
+        }
+      } else if (groupData.admin !== callerUid) {
         throw new HttpsError(
           "permission-denied",
           "Only the group admin may manage members."
         );
       }
 
-      if (action === "remove") {
+      if (action === "remove" || action === "leave") {
         if (targetUserId === groupData.admin) {
           throw new HttpsError(
             "failed-precondition",
-            "Cannot remove the group admin."
+            action === "leave" ?
+              "Group admins can't leave their own group. Transfer ownership or delete the group instead." :
+              "Cannot remove the group admin."
           );
         }
+
+        // Find any upcoming active events in this group so we can check
+        // (transactionally, below) whether the member still has a live
+        // registration that needs withdrawing first — applies to both a
+        // self-service leave and an admin-initiated remove, since either
+        // way a stale participant doc would be left behind (and the
+        // member's spot wouldn't be freed up for the waitlist).
+        const upcomingEvents = await db
+          .collection("events")
+          .where("groupId", "==", groupId)
+          .where("status", "==", "active")
+          .where("eventTimestamp", ">", admin.firestore.Timestamp.now())
+          .get();
+        const upcomingEventRefs = upcomingEvents.docs.map((doc) => doc.ref);
+
         return await db.runTransaction(async (tx) => {
           const memberSnap = await tx.get(memberRef);
           if (!memberSnap.exists) {
@@ -89,9 +120,33 @@ export const manageGroupMember = (db: admin.firestore.Firestore) =>
           if (balance !== 0) {
             throw new HttpsError(
               "failed-precondition",
-              "Member has non-zero balance; cannot remove."
+              action === "leave" ?
+                "Settle your wallet balance with the group admin before leaving." :
+                "Member has non-zero balance; cannot remove."
             );
           }
+
+          if (upcomingEventRefs.length > 0) {
+            const participantSnaps = await Promise.all(
+              upcomingEventRefs.map((eventRef) =>
+                tx.get(eventRef.collection("participants").doc(targetUserId))
+              )
+            );
+            const hasLiveRegistration = participantSnaps.some((snap) => {
+              const status = snap.data()?.status;
+              return status === "confirmed" || status === "waitlisted";
+            });
+            if (hasLiveRegistration) {
+              throw new HttpsError(
+                "failed-precondition",
+                action === "leave" ?
+                  "Withdraw from your upcoming event registrations before leaving the group." :
+                  "This member has an upcoming event registration. They must withdraw themselves, " +
+                    "or the event must be cancelled, before they can be removed."
+              );
+            }
+          }
+
           // Remove membership docs (group side + user index)
           const userIndexRef = db
             .collection("userGroupMemberships")
@@ -100,8 +155,12 @@ export const manageGroupMember = (db: admin.firestore.Firestore) =>
             .doc(groupId);
           tx.delete(memberRef);
           tx.delete(userIndexRef);
-          logger.info("Member removed", {groupId, targetUserId, callerUid});
-          return {status: "removed"};
+          logger.info(action === "leave" ? "Member left group" : "Member removed", {
+            groupId,
+            targetUserId,
+            callerUid,
+          });
+          return {status: action === "leave" ? "left" : "removed"};
         });
       } else if (action === "credit") {
         if (typeof amount !== "number" || amount <= 0) {

--- a/functions/test/manageGroupMember.test.ts
+++ b/functions/test/manageGroupMember.test.ts
@@ -5,6 +5,8 @@ import {
   clearFirestore,
   seedGroup,
   seedMember,
+  seedEvent,
+  seedParticipant,
   getMemberBalance,
   getTransactionsFor,
   callableAuth,
@@ -115,6 +117,23 @@ describe("manageGroupMember", () => {
       expect(memberDoc.exists).toBe(true);
     });
 
+    it("refuses to remove a member with a live upcoming event registration", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, MEMBER_UID, {walletBalance: 0});
+      const eventId = await seedEvent(groupId, {eventTimestamp: new Date(Date.now() + 60 * 60 * 1000)});
+      await seedParticipant(eventId, MEMBER_UID, {status: "confirmed"});
+
+      await expect(
+        wrapped({
+          data: {groupId, targetUserId: MEMBER_UID, action: "remove"},
+          auth: callableAuth(ADMIN_UID),
+        } as never)
+      ).rejects.toMatchObject({code: "failed-precondition"});
+
+      const memberDoc = await db.collection("groups").doc(groupId).collection("members").doc(MEMBER_UID).get();
+      expect(memberDoc.exists).toBe(true);
+    });
+
     it("removes an eligible member and their membership index entry", async () => {
       const groupId = await seedGroup({admin: ADMIN_UID});
       await seedMember(groupId, MEMBER_UID, {walletBalance: 0});
@@ -125,6 +144,97 @@ describe("manageGroupMember", () => {
       } as never);
 
       expect(result).toMatchObject({status: "removed"});
+      const memberDoc = await db.collection("groups").doc(groupId).collection("members").doc(MEMBER_UID).get();
+      expect(memberDoc.exists).toBe(false);
+      const indexDoc = await db
+        .collection("userGroupMemberships")
+        .doc(MEMBER_UID)
+        .collection("groups")
+        .doc(groupId)
+        .get();
+      expect(indexDoc.exists).toBe(false);
+    });
+  });
+
+  describe("leave (self-service)", () => {
+    it("rejects a caller trying to remove someone else", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, MEMBER_UID, {walletBalance: 0});
+
+      await expect(
+        wrapped({
+          data: {groupId, targetUserId: MEMBER_UID, action: "leave"},
+          auth: callableAuth("some-other-uid"),
+        } as never)
+      ).rejects.toMatchObject({code: "permission-denied"});
+    });
+
+    it("refuses to let the group admin leave their own group", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, ADMIN_UID, {walletBalance: 0});
+
+      await expect(
+        wrapped({
+          data: {groupId, targetUserId: ADMIN_UID, action: "leave"},
+          auth: callableAuth(ADMIN_UID),
+        } as never)
+      ).rejects.toMatchObject({code: "failed-precondition"});
+    });
+
+    it("refuses to leave with a non-zero wallet balance", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, MEMBER_UID, {walletBalance: -5});
+
+      await expect(
+        wrapped({
+          data: {groupId, targetUserId: MEMBER_UID, action: "leave"},
+          auth: callableAuth(MEMBER_UID),
+        } as never)
+      ).rejects.toMatchObject({code: "failed-precondition"});
+    });
+
+    it("refuses to leave with a live upcoming waitlisted registration", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, MEMBER_UID, {walletBalance: 0});
+      const eventId = await seedEvent(groupId, {eventTimestamp: new Date(Date.now() + 60 * 60 * 1000)});
+      await seedParticipant(eventId, MEMBER_UID, {status: "waitlisted"});
+
+      await expect(
+        wrapped({
+          data: {groupId, targetUserId: MEMBER_UID, action: "leave"},
+          auth: callableAuth(MEMBER_UID),
+        } as never)
+      ).rejects.toMatchObject({code: "failed-precondition"});
+    });
+
+    it("allows leaving once past-event and withdrawn registrations don't block it", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, MEMBER_UID, {walletBalance: 0});
+      // An upcoming event exists, but this member already withdrew from it —
+      // should not block leaving.
+      const eventId = await seedEvent(groupId, {eventTimestamp: new Date(Date.now() + 60 * 60 * 1000)});
+      await seedParticipant(eventId, MEMBER_UID, {status: "withdrawn"});
+
+      const result = await wrapped({
+        data: {groupId, targetUserId: MEMBER_UID, action: "leave"},
+        auth: callableAuth(MEMBER_UID),
+      } as never);
+
+      expect(result).toMatchObject({status: "left"});
+      const memberDoc = await db.collection("groups").doc(groupId).collection("members").doc(MEMBER_UID).get();
+      expect(memberDoc.exists).toBe(false);
+    });
+
+    it("removes the member and their membership index entry on success", async () => {
+      const groupId = await seedGroup({admin: ADMIN_UID});
+      await seedMember(groupId, MEMBER_UID, {walletBalance: 0});
+
+      const result = await wrapped({
+        data: {groupId, targetUserId: MEMBER_UID, action: "leave"},
+        auth: callableAuth(MEMBER_UID),
+      } as never);
+
+      expect(result).toMatchObject({status: "left"});
       const memberDoc = await db.collection("groups").doc(groupId).collection("members").doc(MEMBER_UID).get();
       expect(memberDoc.exists).toBe(false);
       const indexDoc = await db

--- a/lib/screens/group_details_screen.dart
+++ b/lib/screens/group_details_screen.dart
@@ -11,6 +11,7 @@ import 'package:getspot/services/group_cache_service.dart';
 import 'package:getspot/services/user_cache_service.dart';
 import 'package:getspot/services/event_cache_service.dart';
 import 'package:getspot/services/announcement_cache_service.dart';
+import 'package:getspot/services/analytics_service.dart';
 import 'package:intl/intl.dart';
 import 'package:getspot/screens/group_members_screen.dart';
 import 'package:getspot/screens/wallet_screen.dart';
@@ -174,6 +175,72 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen>
     }
   }
 
+  Future<void> _leaveGroup() async {
+    final groupName = widget.group['name'] ?? 'this group';
+    final groupId = widget.group['groupId'] as String?;
+    final user = FirebaseAuth.instance.currentUser;
+    if (groupId == null || user == null) return;
+
+    final confirmed = await showDialog<bool>(
+          context: context,
+          builder: (ctx) => AlertDialog(
+            title: Text('Leave $groupName?'),
+            content: const Text(
+              'You\'ll need a new invite or the group code to rejoin. Make sure your wallet '
+              'balance is settled and you\'re not registered for any upcoming events first.',
+            ),
+            actions: [
+              TextButton(onPressed: () => Navigator.pop(ctx, false), child: const Text('Cancel')),
+              TextButton(onPressed: () => Navigator.pop(ctx, true), child: const Text('Leave')),
+            ],
+          ),
+        ) ??
+        false;
+
+    if (!confirmed || !mounted) return;
+
+    try {
+      final functions = FirebaseFunctions.instanceFor(region: 'us-east4');
+      final callable = functions.httpsCallable('manageGroupMember');
+      await callable.call({
+        'groupId': groupId,
+        'targetUserId': user.uid,
+        'action': 'leave',
+      });
+
+      developer.log('Left group successfully', name: 'GroupDetailsScreen');
+      GroupCacheService().invalidate(groupId);
+      await AnalyticsService().logLeaveGroup();
+
+      if (mounted) {
+        Navigator.of(context).pop();
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('You\'ve left $groupName.')),
+        );
+      }
+    } on FirebaseFunctionsException catch (e) {
+      developer.log('Error leaving group', name: 'GroupDetailsScreen', error: e);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(e.message ?? 'Could not leave the group.'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    } catch (e) {
+      developer.log('Error leaving group', name: 'GroupDetailsScreen', error: e);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Error leaving group: ${e.toString()}'),
+            backgroundColor: Theme.of(context).colorScheme.error,
+          ),
+        );
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     developer.log('Building GroupDetailsScreen.', name: 'GroupDetailsScreen');
@@ -186,6 +253,18 @@ class _GroupDetailsScreenState extends State<GroupDetailsScreen>
             tooltip: 'Share Group',
             onPressed: _shareGroup,
           ),
+          if (!_isAdmin)
+            PopupMenuButton<String>(
+              onSelected: (value) {
+                if (value == 'leave') _leaveGroup();
+              },
+              itemBuilder: (context) => const [
+                PopupMenuItem(
+                  value: 'leave',
+                  child: Text('Leave Group'),
+                ),
+              ],
+            ),
         ],
         bottom: TabBar(
           controller: _tabController,


### PR DESCRIPTION
## Summary
- `faq_screen.dart` already told users they could leave a group via a "Leave Group" menu item, but no such feature existed anywhere: no menu item in `group_details_screen.dart`, no self-service backend path (`manageGroupMember`'s `remove` action required the *caller* to be the group admin), and no Security Rules allowance for self-delete. `AnalyticsService.logLeaveGroup()` was defined but never called.
- Adds a `leave` action to `manageGroupMember` alongside the existing admin-only `remove`: same preconditions (not the group admin, zero wallet balance), but authorized by self instead of admin status.
- Also extends the upcoming-event-registration guard to admin-initiated `remove`, so an admin can't remove a member who's still confirmed/waitlisted for a future event and leave a stale participant doc behind (previously only `leave` had this check).
- `group_details_screen.dart` gets a "Leave Group" overflow menu item (hidden for the group's admin, since they can't leave their own group), a confirmation dialog, and error messages sourced from the callable's own precondition failures rather than duplicated client-side.
- 7 new test cases in `manageGroupMember.test.ts` (self-leave guards, the extended `remove` guard), run against the Firestore emulator.

## Test plan
- [x] `flutter analyze` clean
- [x] `npm run lint` / `npm run build` / `npm test` clean in `functions/` — 34/34 tests passing
- [ ] Manually verify: a non-admin member sees "Leave Group", leaves successfully when eligible, and gets the right blocking message when carrying a balance or an upcoming registration
- [ ] Manually verify: the group admin does not see "Leave Group" at all