### PR TITLE
fix(ci): install JDK 21 before running functions unit tests

### DIFF
--- a/.github/workflows/dry-run-functions.yml
+++ b/.github/workflows/dry-run-functions.yml
@@ -36,6 +36,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Set up Java
+        # The Firestore emulator (used by the unit test suite below) requires
+        # JDK 21+; ubuntu-latest's default java isn't guaranteed to satisfy that.
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Summary
- The "Run unit tests" step added in #104 fails on every PR touching `functions/` with `firebase-tools no longer supports Java version before 21` — `ubuntu-latest`'s default `java` on PATH isn't guaranteed to be JDK 21+, which `firebase-tools`' Firestore emulator now requires.
- Surfaced on PR #106: https://github.com/amitrke/getspot/actions/runs/32661600734
- Adds `actions/setup-java@v4` (Temurin 21) before the Node/pnpm setup steps.

## Test plan
- [ ] Confirm this PR's own "Run unit tests" step passes (it exercises the exact fix)