### PR TITLE
fix(security): require the group's real admin to create events

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -71,7 +71,13 @@ service cloud.firestore {
 
     match /events/{eventId} {
       allow read: if exists(/databases/$(database)/documents/groups/$(resource.data.groupId)/members/$(request.auth.uid));
-      allow create: if exists(/databases/$(database)/documents/groups/$(request.resource.data.groupId)/members/$(request.auth.uid))
+      // Only the group's admin may create events — the client UI only ever
+      // exposes event creation to admins, but nothing enforced that
+      // server-side: any member could otherwise write an events doc
+      // directly and set an arbitrary `admin` field on it. Both are
+      // asserted here rather than trusting the client-provided `admin`.
+      allow create: if request.auth.uid == get(/databases/$(database)/documents/groups/$(request.resource.data.groupId)).data.admin
+                    && request.resource.data.admin == request.auth.uid
                     && request.resource.data.maxParticipants > 0
                     && request.resource.data.maxParticipants <= get(/databases/$(database)/documents/groups/$(request.resource.data.groupId)).data.maxEventCapacity;
       // Admin can update/delete events. Note: maxParticipants updates are handled via Cloud Function for safety


### PR DESCRIPTION
## Summary
- The `events` `create` rule only checked that the caller was *a member* of the group — the client UI (`group_details_screen.dart`) only ever exposes event creation to admins, but nothing enforced that server-side. Any regular member could write an events doc directly via the SDK and set an arbitrary `admin` field on it.
- Nothing currently trusts that field for authorization (Cloud Functions re-check the group's real admin for privileged actions, and the UI passes down `isGroupAdmin` from the group doc, not the event doc), so this was a data-integrity gap rather than an active privilege escalation — but it also means, more importantly, that only the group admin should be able to create events at all, matching the app's actual design, which wasn't enforced.
- Now requires `request.auth.uid` to equal the group's real admin, and asserts `request.resource.data.admin` matches it too.

## Test plan
- **Verified against a real Firestore emulator** (not just reasoned about), 7/7 assertions passing:
  - [x] Admin creates an event with the correct `admin` field → allowed
  - [x] Admin creates an event but spoofs a different `admin` field → denied
  - [x] Non-admin member creates an event, even with the real admin's uid on it → denied
  - [x] Non-admin member creates an event claiming themselves as admin → denied
  - [x] Non-member (not even in the group) → denied
  - [x] `maxParticipants` over the group's cap → still denied (regression check)
  - [x] `maxParticipants` <= 0 → still denied (regression check)
- No `functions/` code touched, so the Cloud Functions test suite is unaffected by this change.

⚠️ This changes Firestore Security Rules — those only deploy to production on push to `main` (`deploy-firestore-rules.yml`), so this isn't live until the next `develop` → `main` release PR merges.