### PR TITLE
fix(ios): correct bundle identifier in App Store promotion workflow

### DIFF
--- a/.github/workflows/promote-to-appstore.yml
+++ b/.github/workflows/promote-to-appstore.yml
@@ -49,7 +49,7 @@ jobs:
           APP_APPLE_ID: ${{ secrets.APP_APPLE_ID }}
         run: |
           cat > ./fastlane/.env << EOF
-          APP_IDENTIFIER=com.getspot.app
+          APP_IDENTIFIER=org.getspot
           APP_STORE_CONNECT_API_KEY_PATH=./fastlane/app_store_connect_api_key.json
           APP_APPLE_ID=$APP_APPLE_ID
           EOF

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -62,5 +62,3 @@ Building, signing, and uploading to TestFlight is automated via GitHub Actions (
 1. Go to **GitHub → Actions → "Manual iOS TestFlight Deployment"** (`.github/workflows/deploy-ios-manual.yml`), run via `workflow_dispatch`, and supply the base version (e.g. `1.0.3`) — the build number is set to the GitHub Actions run number.
 2. The workflow builds an unsigned IPA (`flutter build ipa --no-codesign`) and uploads it to TestFlight via Fastlane (`pilot upload`).
 3. **Promote to App Store review:** run **"Promote to App Store"** (`.github/workflows/promote-to-appstore.yml`) via `workflow_dispatch`, optionally specifying a build number (defaults to latest). This runs `fastlane promote_to_review`/`promote_build` to move the TestFlight build to App Store review — no local Xcode step needed.
-
-> **Known issue:** `promote-to-appstore.yml` currently hardcodes `APP_IDENTIFIER=com.getspot.app` in its generated `.env`, but the app's real bundle ID is `org.getspot`. This looks like the same stale-identifier issue found elsewhere in the docs, but it's in a live workflow file — worth verifying/fixing separately before relying on this workflow.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,7 +110,7 @@ platform :ios do
 
     # Get the latest build number from TestFlight
     latest_build = latest_testflight_build_number(
-      app_identifier: ENV["APP_IDENTIFIER"] || "com.getspot.app",
+      app_identifier: ENV["APP_IDENTIFIER"] || "org.getspot",
       api_key: api_key
     )
 
@@ -119,7 +119,7 @@ platform :ios do
     # Deliver the build to App Store Review
     deliver(
       api_key: api_key,
-      app_identifier: ENV["APP_IDENTIFIER"] || "com.getspot.app",
+      app_identifier: ENV["APP_IDENTIFIER"] || "org.getspot",
       build_number: latest_build.to_s,
       submit_for_review: true,
       automatic_release: false, # Set to true if you want auto-release after approval
@@ -157,7 +157,7 @@ platform :ios do
 
     deliver(
       api_key: api_key,
-      app_identifier: ENV["APP_IDENTIFIER"] || "com.getspot.app",
+      app_identifier: ENV["APP_IDENTIFIER"] || "org.getspot",
       build_number: build_number.to_s,
       submit_for_review: true,
       automatic_release: false,


### PR DESCRIPTION
## Summary
- `promote-to-appstore.yml` hardcoded `APP_IDENTIFIER=com.getspot.app` in its generated `.env`, but the app's real bundle ID (`ios/Runner.xcodeproj/project.pbxproj`) is `org.getspot`.
- Traced the impact: `promote_to_review`/`promote_build` in `fastlane/Fastfile` always read `APP_IDENTIFIER` from that env var (the workflow sets it unconditionally, so the fallback default never applies), meaning this workflow currently would look up TestFlight builds and submit for review under a bundle ID that doesn't exist in App Store Connect — it's non-functional as-is.
- Also fixes the same wrong fallback default (`com.getspot.app`) in those two Fastfile lanes, for consistency with `upload_screenshots`, which already correctly defaulted to `org.getspot`.
- Removes the now-resolved known-issue callout from `docs/DEPLOYMENT.md`.

## Test plan
- [x] Confirmed `org.getspot` is the real bundle ID via `ios/Runner.xcodeproj/project.pbxproj` (`PRODUCT_BUNDLE_IDENTIFIER`)
- [ ] Manually verify: run "Promote to App Store" via `workflow_dispatch` against a real TestFlight build and confirm it now finds/submits it (I can't exercise this myself — it needs App Store Connect credentials and a real build)