### PR TITLE
feat(main): publish a real /privacy page, replacing the dead GitHub Pages link

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,6 +1,6 @@
 # Privacy Policy for GetSpot
 
-**Last Updated: October 1, 2025**
+**Last Updated: August 23, 2026**
 
 Thank you for using GetSpot. This Privacy Policy explains how we collect, use, and share information about you when you use our mobile application and related services (collectively, the "Services").
 
@@ -72,11 +72,9 @@ You have the right to access, update, or delete your personal information. You c
 
 ### 7. Data Deletion Request
 
-You can request the deletion of your account and all associated data. To do so, please use the following link to open a data deletion request.
+You can delete your account and all associated data directly within the app: open your profile screen and tap "Delete Account." This is immediate and cannot be undone. If you have a negative wallet balance in any group, you'll need to settle it with your group admin before you can delete your account.
 
-**[Request Data Deletion](https://github.com/amitrke/getspot/issues/new?title=Data+Deletion+Request)**
-
-We will process your request after verifying your identity to protect your account from fraudulent deletion requests.
+If you're unable to access the app, you can email [support@getspot.org](mailto:support@getspot.org) to request deletion instead.
 
 ---
 
@@ -94,4 +92,4 @@ We may update this Privacy Policy from time to time. We will notify you of any c
 
 ### 10. Contact Us
 
-If you have any questions about this Privacy Policy, please [open an issue on our GitHub repository](https://github.com/amitrke/getspot/issues/new).
+If you have any questions about this Privacy Policy, please email [support@getspot.org](mailto:support@getspot.org).

--- a/main/src/app/privacy/page.tsx
+++ b/main/src/app/privacy/page.tsx
@@ -1,0 +1,211 @@
+import type { Metadata } from "next";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy — GetSpot",
+  description: "How GetSpot collects, uses, and shares information about you when you use the app.",
+};
+
+function Section({
+  number,
+  title,
+  children,
+}: {
+  number: number;
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="mt-10 border-t border-zinc-200 pt-10 first:mt-0 first:border-t-0 first:pt-0 dark:border-zinc-800">
+      <h2 className="text-lg font-semibold">
+        {number}. {title}
+      </h2>
+      <div className="mt-3 space-y-3 text-sm text-zinc-500 dark:text-zinc-400">{children}</div>
+    </section>
+  );
+}
+
+export default function PrivacyPage() {
+  return (
+    <div className="flex flex-1 flex-col bg-white text-zinc-900 dark:bg-zinc-950 dark:text-zinc-50">
+      <Header />
+
+      <main className="mx-auto w-full max-w-2xl flex-1 px-5 py-16 sm:py-24">
+        <div className="text-center">
+          <h1 className="text-4xl font-semibold tracking-tight sm:text-5xl">Privacy Policy</h1>
+          <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">Last Updated: August 23, 2026</p>
+        </div>
+
+        <p className="mt-10 text-sm text-zinc-500 dark:text-zinc-400">
+          Thank you for using GetSpot. This Privacy Policy explains how we collect, use, and share
+          information about you when you use our mobile application and related services (collectively,
+          the &ldquo;Services&rdquo;).
+        </p>
+
+        <p className="mt-4 text-sm text-zinc-500 dark:text-zinc-400">
+          <strong className="text-zinc-700 dark:text-zinc-300">Disclaimer:</strong> This is a template
+          privacy policy and does not constitute legal advice. You should consult with a legal professional
+          to ensure this policy is appropriate and compliant for your specific situation.
+        </p>
+
+        <div className="mt-16">
+          <Section number={1} title="Information We Collect">
+            <p>
+              We collect information you provide directly to us and information that is collected
+              automatically through your use of our Services.
+            </p>
+            <p className="font-semibold text-zinc-700 dark:text-zinc-300">a) Information You Provide to Us:</p>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">Account Information:</strong> When you
+                register for an account, we collect your name and email address through Firebase
+                Authentication.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">Group Information:</strong> We collect
+                information about the groups you create or join, including the group name, description, and
+                members.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">Event Information:</strong> We collect
+                details about the events you create or register for, including event name, time, fee, and
+                your participation status.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">Wallet and Transaction Information:</strong>{" "}
+                We maintain a record of your virtual wallet balance and a history of all transactions (e.g.,
+                event fee payments, penalties, refunds) associated with your account.
+              </li>
+            </ul>
+            <p className="font-semibold text-zinc-700 dark:text-zinc-300">b) Information We Collect Automatically:</p>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">Usage Information:</strong> We collect
+                information about your activity on the Services, such as which features you use and when you
+                use them.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">Device Information:</strong> We may
+                collect information about the device you use to access our Services, including the hardware
+                model, operating system, and unique device identifiers.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">
+                  Firebase Cloud Messaging (FCM) Token:
+                </strong>{" "}
+                To send you push notifications, we collect and store your FCM registration token.
+              </li>
+            </ul>
+          </Section>
+
+          <Section number={2} title="How We Use Your Information">
+            <p>We use the information we collect to:</p>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>Provide, maintain, and improve our Services.</li>
+              <li>Create and manage your account, groups, and events.</li>
+              <li>Process transactions for your virtual wallet.</li>
+              <li>
+                Communicate with you, including sending event reminders, waitlist updates, and other
+                service-related notifications.
+              </li>
+              <li>Ensure the security of our Services.</li>
+              <li>Personalize your experience.</li>
+            </ul>
+          </Section>
+
+          <Section number={3} title="How We Share Your Information">
+            <p>We may share your information in the following situations:</p>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">With Other Group Members:</strong> Your
+                name and participation status for events are visible to other members of the groups you are
+                in. Group administrators can also view member wallet balances.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">With Service Providers:</strong> We use
+                third-party service providers to help us operate our Services, such as Google Firebase for
+                backend infrastructure, authentication, and hosting. These providers have access to your
+                information only to perform services on our behalf and are obligated not to disclose or use
+                it for any other purpose.
+              </li>
+              <li>
+                <strong className="text-zinc-700 dark:text-zinc-300">For Legal Reasons:</strong> We may
+                disclose your information if we believe that it is reasonably necessary to comply with a law,
+                regulation, legal process, or governmental request.
+              </li>
+            </ul>
+            <p>We do not sell your personal information to third parties.</p>
+          </Section>
+
+          <Section number={4} title="Data Security">
+            <p>
+              We use Google Firebase, which implements industry-standard security measures to protect your
+              information from unauthorized access, alteration, disclosure, or destruction. However, no
+              security system is impenetrable, and we cannot guarantee the absolute security of your
+              information.
+            </p>
+          </Section>
+
+          <Section number={5} title="Data Retention">
+            <p>
+              We retain your personal information for as long as your account is active or as needed to
+              provide you with the Services. We may also retain information to comply with our legal
+              obligations, resolve disputes, and enforce our agreements.
+            </p>
+          </Section>
+
+          <Section number={6} title="Your Rights">
+            <p>
+              You have the right to access, update, or delete your personal information. You can manage most
+              of your information directly within the app.
+            </p>
+          </Section>
+
+          <Section number={7} title="Data Deletion Request">
+            <p>
+              You can delete your account and all associated data directly within the app: open your profile
+              screen and tap &ldquo;Delete Account.&rdquo; This is immediate and cannot be undone. If you have
+              a negative wallet balance in any group, you&apos;ll need to settle it with your group admin
+              before you can delete your account.
+            </p>
+            <p>
+              If you&apos;re unable to access the app, you can email{" "}
+              <a href="mailto:support@getspot.org" className="underline hover:no-underline">
+                support@getspot.org
+              </a>{" "}
+              to request deletion instead.
+            </p>
+          </Section>
+
+          <Section number={8} title="Children's Privacy">
+            <p>
+              Our Services are not directed to individuals under the age of 13. We do not knowingly collect
+              personal information from children under 13. If we become aware that a child under 13 has
+              provided us with personal information, we will take steps to delete such information.
+            </p>
+          </Section>
+
+          <Section number={9} title="Changes to This Policy">
+            <p>
+              We may update this Privacy Policy from time to time. We will notify you of any changes by
+              posting the new Privacy Policy on this page and updating the &ldquo;Last Updated&rdquo; date.
+            </p>
+          </Section>
+
+          <Section number={10} title="Contact Us">
+            <p>
+              If you have any questions about this Privacy Policy, please email{" "}
+              <a href="mailto:support@getspot.org" className="underline hover:no-underline">
+                support@getspot.org
+              </a>
+              .
+            </p>
+          </Section>
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/main/src/components/Footer.tsx
+++ b/main/src/components/Footer.tsx
@@ -1,10 +1,13 @@
+import Link from "next/link";
+
 export default function Footer() {
   return (
     <footer className="mx-auto w-full max-w-3xl px-5 py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
       © 2026 GetSpot ·{" "}
       <a href="https://app.getspot.org" className="hover:underline">
         app.getspot.org
-      </a>
+      </a>{" "}
+      · <Link href="/privacy" className="hover:underline">Privacy</Link>
     </footer>
   );
 }


### PR DESCRIPTION
## Summary
- The old privacy policy lived at `amitrke.github.io/getspot/privacy.html` via GitHub Pages, which has since been disabled (a pure repo-settings toggle, so it left no trace in git history) — that URL 404s today, including everywhere the app stores currently reference it (confirmed both Play Console and App Store Connect still point at it).
- Publishes the same content as a real `/privacy` page on the live marketing site (`getspot.org`) instead of resurrecting a separate GitHub Pages domain. Styled to match the existing FAQ/features pages, linked from the footer on every page.
- `docs/privacy.md` stays the source-of-truth markdown, kept in sync with the live page.
- Two content updates versus the old copy, both to match how the app actually works today (checked against `member_profile_screen.dart` and `requestAccountDeletion.ts`):
  - Data deletion now describes the real in-app "Delete Account" flow instead of a GitHub-issue request process that was never built
  - Contact points to `support@getspot.org` instead of GitHub issues, matching the FAQ page

## Test plan
- [x] `npm run lint` / `npm run build` clean in `main/`
- [ ] Visually review the rendered page once deployed
- [ ] Once live, update the Privacy Policy URL in both Play Console and App Store Connect to `https://www.getspot.org/privacy` (currently still pointing at the dead link) — this needs a `develop` → `main` release to actually go live on getspot.org, not just merging this PR