### PR TITLE
fix(ios): correct two more stale com.getspot.app bundle ID references

### DIFF
--- a/docs/IN_APP_UPDATES.md
+++ b/docs/IN_APP_UPDATES.md
@@ -179,7 +179,7 @@ UpgradeCard(
 ## Store Requirements
 
 ### iOS (App Store)
-- **Bundle ID**: Must match the one in App Store Connect (e.g., `com.getspot.app`)
+- **Bundle ID**: Must match the one in App Store Connect (`org.getspot`)
 - **Version Format**: Follows `CFBundleShortVersionString` (e.g., `1.0.1`)
 - **Lookup**: Uses iTunes Search API (no authentication needed)
 

--- a/fastlane/.env.default
+++ b/fastlane/.env.default
@@ -3,7 +3,7 @@
 # DO NOT commit .env to git (it's in .gitignore)
 
 # Your app's bundle identifier
-APP_IDENTIFIER="com.getspot.app"
+APP_IDENTIFIER="org.getspot"
 
 # App Store Connect API Key credentials
 # Get these from: https://appstoreconnect.apple.com/access/api

--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,4 +1,4 @@
-app_identifier(ENV["APP_IDENTIFIER"] || "com.getspot.app")
+app_identifier(ENV["APP_IDENTIFIER"] || "org.getspot")
 apple_id(ENV["APP_APPLE_ID"]) # Your Apple email address
 
 # For more information about the Appfile, see:


### PR DESCRIPTION
## Summary
Found while reviewing fastlane metadata (#113): `fastlane/Appfile` and `fastlane/.env.default` still had the wrong bundle ID fallback (`com.getspot.app`) that #110 fixed in `promote-to-appstore.yml` and the Fastfile lanes, but missed here. `Appfile` matters most — it's fastlane's global default, used whenever `APP_IDENTIFIER` isn't explicitly set. Also fixed a stray doc reference in `IN_APP_UPDATES.md` for consistency.

## Test plan
- [x] `ruby -c fastlane/Appfile` clean