### PR TITLE
fix(hosting): enable cleanUrls on the main site — every internal nav link 404s in production

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -55,6 +55,7 @@
     {
       "target": "main",
       "public": "main/out",
+      "cleanUrls": true,
       "ignore": [
         "firebase.json",
         "**/.*",


### PR DESCRIPTION
## Summary
Discovered while verifying the new `/privacy` page went live: it 404'd even after a successful deploy. Root cause is **repo-wide, not specific to that page** — the `main` Firebase Hosting target never had `cleanUrls` set, so only the exact `*.html` filename resolves (`/privacy.html` → 200) while the clean path used by every internal link in the app (`/privacy`, `/faq`, `/features` — `Header.tsx`'s nav, `Footer.tsx`) 404s.

**Confirmed live right now, before this fix**: `/faq` and `/features` are broken in production the exact same way `/privacy` was — this predates the privacy page work entirely.

`cleanUrls: true` is the standard fix for a Next.js static export (`output: "export"`) deployed to Firebase Hosting — it serves `/foo` from `/foo.html` automatically. Scoped to the `main` target only; the `app` target (Flutter web) already has its own SPA catch-all rewrite and doesn't need this.

## Test plan
- [x] `firebase.json` JSON syntax validated
- [ ] After deploy: confirm `https://www.getspot.org/faq`, `/features`, and `/privacy` all return 200 (currently only the `.html` variants do)

⚠️ This is a live production bug affecting site navigation right now — worth fast-tracking to `main` once merged here, same as the privacy page release.