### PR TITLE
HOTFIX: revert /groups list restriction — production outage for app users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -35,15 +35,16 @@ service cloud.firestore {
     }
 
     match /groups/{groupId} {
-      // get (single doc by known ID) is safe to leave open — group IDs are
-      // unguessable Firestore auto-IDs. list is denied outright: Firestore
-      // can't redact fields per query, so an open list would let any
-      // authenticated user enumerate every group's admin uid,
-      // negativeBalanceLimit, etc. The one legitimate non-member lookup
-      // (join by code) goes through the findGroupByCode callable instead,
-      // which runs with Admin SDK privileges and returns only safe fields.
-      allow get, create: if request.auth != null;
-      allow list: if false;
+      // TEMPORARY REVERT (see GitHub issue for tracking): `allow list: if
+      // false` broke "load groups" for every iOS/Android user still on an
+      // app build older than the client-side fix that stopped querying
+      // /groups with whereIn(documentId) — those old builds can't be force-
+      // updated, and Firestore rules deploy instantly while app store
+      // releases don't, so tightening this broke production before any
+      // client could have picked up the compatible query pattern. Reopening
+      // `list` restores service; re-tighten once the fixed app version has
+      // had time to roll out to the userbase.
+      allow read, create: if request.auth != null;
       allow update, delete: if request.auth.uid == resource.data.admin;
 
       //--- SUBCOLLECTIONS ---//


### PR DESCRIPTION
## 🔴 Production incident

iOS/Android app users are currently seeing "Error loading groups" / `cloud_firestore/permission-denied` on the home screen. Web is unaffected.

## Root cause
`allow list: if false` on `/groups/{groupId}` (from #106, live on `main` since the last release) denies the `whereIn(documentId)` query that **existing installed app builds** still use to load the group list. That client-side fix (individual `.get()` calls instead of `whereIn`) exists in the current codebase, but hasn't shipped to users yet — app store releases take time, and Firestore rules deploy instantly on merge. So the rule tightened before any client in the wild could handle it.

Web is fine because it redeploys the latest client code on every merge — no stale-client problem there.

## Fix
Reverts `/groups/{groupId}`'s read rule to the prior permissive version (`allow read, create: if request.auth != null`), restoring service immediately. This reopens the enumeration exposure #106 closed — tracked in a follow-up issue to re-apply once the fixed app version has had time to actually reach users.

## Test plan
- [x] Reverts to exactly the rule that was live and working before #106
- [ ] **Please merge and deploy ASAP** — this is blocking real users right now
- [ ] Confirm `deploy-firestore-rules.yml` runs and completes on merge
- [ ] Confirm app users can load groups again post-deploy