### PR TITLE
fix(ci): pass api_key_path into deliver for update_metadata lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -212,6 +212,7 @@ platform :ios do
   desc "Update App Store metadata only (no build submission)"
   lane :update_metadata do
     deliver(
+      api_key_path: ENV["APP_STORE_CONNECT_API_KEY_PATH"],
       app_identifier: ENV["APP_IDENTIFIER"],
       skip_binary_upload: true,
       # Screenshots aren't synced via this lane yet — leaving this false with


### PR DESCRIPTION
## Summary
- The `update_metadata` fastlane lane never forwarded `APP_STORE_CONNECT_API_KEY_PATH` into `deliver(...)`, so the last run of `update-ios-metadata.yml` failed with `'api_key' value must be a Hash! Found String instead.`
- That run was meant to push the corrected privacy policy URL (from PR #114) to App Store Connect — the live App Store listing is still showing the dead `amitrke.github.io/getspot/privacy.html` link (see issue #124).
- Fix mirrors the pattern already used by `promote_build`/`promote_to_review`: pass the API key explicitly instead of relying on implicit env pickup.

## Test plan
- [ ] Merge, then re-run `update-ios-metadata.yml` via workflow_dispatch and confirm it succeeds
- [ ] Verify the App Store Connect privacy policy URL updates to `https://www.getspot.org/privacy`