### PR TITLE
fix(ci): make update-ios-metadata actually work end-to-end

### DIFF
--- a/.github/workflows/update-ios-metadata.yml
+++ b/.github/workflows/update-ios-metadata.yml
@@ -54,12 +54,16 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
         run: |
+          # The private key is a multi-line PEM. A raw multi-line value breaks
+          # .env's line-based KEY=VALUE parsing, so collapse it to literal \n
+          # escapes here — the Fastfile un-escapes it back before use.
+          ESCAPED_KEY="${APP_STORE_CONNECT_API_KEY//$'\n'/\\n}"
           cat > ./fastlane/.env << EOF
           APP_IDENTIFIER=org.getspot
           APP_STORE_CONNECT_API_KEY_PATH=./fastlane/app_store_connect_api_key.json
           APP_STORE_CONNECT_API_KEY_ID=$APP_STORE_CONNECT_API_KEY_ID
           APP_STORE_CONNECT_API_ISSUER_ID=$APP_STORE_CONNECT_API_ISSUER_ID
-          APP_STORE_CONNECT_API_KEY=$APP_STORE_CONNECT_API_KEY
+          APP_STORE_CONNECT_API_KEY=$ESCAPED_KEY
           APP_APPLE_ID=$APP_APPLE_ID
           EOF
 

--- a/.github/workflows/update-ios-metadata.yml
+++ b/.github/workflows/update-ios-metadata.yml
@@ -54,16 +54,19 @@ jobs:
           APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
           APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
         run: |
-          # The private key is a multi-line PEM. A raw multi-line value breaks
-          # .env's line-based KEY=VALUE parsing, so collapse it to literal \n
-          # escapes here — the Fastfile un-escapes it back before use.
-          ESCAPED_KEY="${APP_STORE_CONNECT_API_KEY//$'\n'/\\n}"
+          # The private key is a multi-line PEM. Passing it through GitHub
+          # Actions secrets/.env as raw text mangles its newlines, which
+          # OpenSSL then rejects as "invalid curve name" (see
+          # fastlane/fastlane#29478) — base64-encode it instead so it
+          # survives as a single line, and decode with is_key_content_base64
+          # in the Fastfile.
+          ENCODED_KEY=$(printf '%s' "$APP_STORE_CONNECT_API_KEY" | base64 | tr -d '\n')
           cat > ./fastlane/.env << EOF
           APP_IDENTIFIER=org.getspot
           APP_STORE_CONNECT_API_KEY_PATH=./fastlane/app_store_connect_api_key.json
           APP_STORE_CONNECT_API_KEY_ID=$APP_STORE_CONNECT_API_KEY_ID
           APP_STORE_CONNECT_API_ISSUER_ID=$APP_STORE_CONNECT_API_ISSUER_ID
-          APP_STORE_CONNECT_API_KEY=$ESCAPED_KEY
+          APP_STORE_CONNECT_API_KEY=$ENCODED_KEY
           APP_APPLE_ID=$APP_APPLE_ID
           EOF
 

--- a/.github/workflows/update-ios-metadata.yml
+++ b/.github/workflows/update-ios-metadata.yml
@@ -50,10 +50,16 @@ jobs:
       - name: Create .env file
         env:
           APP_APPLE_ID: ${{ secrets.APP_APPLE_ID }}
+          APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+          APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+          APP_STORE_CONNECT_API_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
         run: |
           cat > ./fastlane/.env << EOF
           APP_IDENTIFIER=org.getspot
           APP_STORE_CONNECT_API_KEY_PATH=./fastlane/app_store_connect_api_key.json
+          APP_STORE_CONNECT_API_KEY_ID=$APP_STORE_CONNECT_API_KEY_ID
+          APP_STORE_CONNECT_API_ISSUER_ID=$APP_STORE_CONNECT_API_ISSUER_ID
+          APP_STORE_CONNECT_API_KEY=$APP_STORE_CONNECT_API_KEY
           APP_APPLE_ID=$APP_APPLE_ID
           EOF
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -210,7 +210,7 @@ platform :ios do
   end
 
   desc "Update App Store metadata only (no build submission)"
-  lane :update_metadata do
+  lane :update_metadata do |options|
     # Load API key from environment. The key is base64-encoded before it's
     # written into .env (see the workflow) — a raw multi-line PEM passed
     # through GitHub Actions secrets/.env gets its newlines mangled, which
@@ -223,9 +223,20 @@ platform :ios do
       in_house: false
     )
 
+    # The live version has no editable version to attach metadata changes
+    # to, and edit_live: true hits a fastlane 2.238.0 bug (nil vs Array in
+    # upload_metadata.rb) as soon as it tries to upload anything — it's
+    # unconditional, skip_app_version_update doesn't avoid it either.
+    # Target/create a draft next-version instead, which goes through
+    # deliver's normal, non-buggy path. Pass app_version explicitly (rather
+    # than letting deliver auto-detect one) so it doesn't spend ~20 minutes
+    # retrying to find a pending version that doesn't exist yet.
+    app_version = options[:app_version] || "1.0.4"
+
     deliver(
       api_key: api_key,
       app_identifier: ENV["APP_IDENTIFIER"],
+      app_version: app_version,
       skip_binary_upload: true,
       # Screenshots aren't synced via this lane yet — leaving this false with
       # no local fastlane/metadata/en-US/screenshots content risked deliver
@@ -233,21 +244,7 @@ platform :ios do
       # added to this repo.
       skip_screenshots: true,
       force: true,
-      # No draft version exists most of the time (app is live, fully
-      # approved) — edit the live version's metadata directly instead of
-      # waiting for a pending version that isn't there.
-      edit_live: true,
-      # Default is 7 retries with growing waits (up to ~20 min total) for a
-      # pending version to appear — pointless here since edit_live means
-      # there's nothing to wait for.
-      version_check_wait_retry_limit: 1,
-      # deliver 2.238.0 has a bug where edit_live: true skips initializing
-      # app_store_version_localizations but later unconditionally
-      # batch_enqueues it, crashing with "Enqueue Array instead of
-      # NilClass". We only need App Info-level fields (privacy_url) here,
-      # not version-scoped ones (description/keywords/promotional_text),
-      # so skip that step entirely and route around the bug.
-      skip_app_version_update: true
+      version_check_wait_retry_limit: 1
     )
 
     UI.success("✅ Metadata updated on App Store Connect!")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,11 +211,14 @@ platform :ios do
 
   desc "Update App Store metadata only (no build submission)"
   lane :update_metadata do
-    # Load API key from environment
+    # Load API key from environment. The key is stored with literal \n
+    # escapes (see fastlane/.env.default) since a raw multi-line PEM breaks
+    # .env parsing — un-escape it back into real newlines here, or OpenSSL
+    # fails with "invalid curve name" trying to parse the mangled PEM.
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
-      key_content: ENV["APP_STORE_CONNECT_API_KEY"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY"].to_s.gsub('\n', "\n"),
       is_key_content_base64: false,
       in_house: false
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -244,7 +244,13 @@ platform :ios do
       # added to this repo.
       skip_screenshots: true,
       force: true,
-      version_check_wait_retry_limit: 1
+      version_check_wait_retry_limit: 1,
+      # precheck's In-App Purchase check isn't supported with API-key auth
+      # ("Precheck cannot check In-app purchases with the App Store Connect
+      # API Key (yet)") and we're not submitting for review here anyway
+      # (submit_for_review defaults to false), so there's nothing to
+      # precheck for.
+      run_precheck_before_submit: false
     )
 
     UI.success("✅ Metadata updated on App Store Connect!")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,8 +211,17 @@ platform :ios do
 
   desc "Update App Store metadata only (no build submission)"
   lane :update_metadata do
+    # Load API key from environment
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
+      key_content: ENV["APP_STORE_CONNECT_API_KEY"],
+      is_key_content_base64: false,
+      in_house: false
+    )
+
     deliver(
-      api_key_path: ENV["APP_STORE_CONNECT_API_KEY_PATH"],
+      api_key: api_key,
       app_identifier: ENV["APP_IDENTIFIER"],
       skip_binary_upload: true,
       # Screenshots aren't synced via this lane yet — leaving this false with

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -232,7 +232,15 @@ platform :ios do
       # erroring or touching what's live. Flip to false once screenshots are
       # added to this repo.
       skip_screenshots: true,
-      force: true
+      force: true,
+      # No draft version exists most of the time (app is live, fully
+      # approved) — edit the live version's metadata directly instead of
+      # waiting for a pending version that isn't there.
+      edit_live: true,
+      # Default is 7 retries with growing waits (up to ~20 min total) for a
+      # pending version to appear — pointless here since edit_live means
+      # there's nothing to wait for.
+      version_check_wait_retry_limit: 1
     )
 
     UI.success("✅ Metadata updated on App Store Connect!")

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -211,15 +211,15 @@ platform :ios do
 
   desc "Update App Store metadata only (no build submission)"
   lane :update_metadata do
-    # Load API key from environment. The key is stored with literal \n
-    # escapes (see fastlane/.env.default) since a raw multi-line PEM breaks
-    # .env parsing — un-escape it back into real newlines here, or OpenSSL
-    # fails with "invalid curve name" trying to parse the mangled PEM.
+    # Load API key from environment. The key is base64-encoded before it's
+    # written into .env (see the workflow) — a raw multi-line PEM passed
+    # through GitHub Actions secrets/.env gets its newlines mangled, which
+    # OpenSSL rejects as "invalid curve name" (fastlane/fastlane#29478).
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
-      key_content: ENV["APP_STORE_CONNECT_API_KEY"].to_s.gsub('\n', "\n"),
-      is_key_content_base64: false,
+      key_content: ENV["APP_STORE_CONNECT_API_KEY"],
+      is_key_content_base64: true,
       in_house: false
     )
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -240,7 +240,14 @@ platform :ios do
       # Default is 7 retries with growing waits (up to ~20 min total) for a
       # pending version to appear — pointless here since edit_live means
       # there's nothing to wait for.
-      version_check_wait_retry_limit: 1
+      version_check_wait_retry_limit: 1,
+      # deliver 2.238.0 has a bug where edit_live: true skips initializing
+      # app_store_version_localizations but later unconditionally
+      # batch_enqueues it, crashing with "Enqueue Array instead of
+      # NilClass". We only need App Info-level fields (privacy_url) here,
+      # not version-scoped ones (description/keywords/promotional_text),
+      # so skip that step entirely and route around the bug.
+      skip_app_version_update: true
     )
 
     UI.success("✅ Metadata updated on App Store Connect!")

--- a/fastlane/metadata/en-US/name.txt
+++ b/fastlane/metadata/en-US/name.txt
@@ -1,1 +1,1 @@
-GetSpot
+Sports GetSpot

--- a/fastlane/metadata/en-US/promotional_text.txt
+++ b/fastlane/metadata/en-US/promotional_text.txt
@@ -1,0 +1,1 @@
+Run your badminton, soccer, or pickleball group without the chaos. Schedule events, track RSVPs, and manage payments — all in one place.

--- a/fastlane/metadata/en-US/release_notes.txt
+++ b/fastlane/metadata/en-US/release_notes.txt
@@ -1,0 +1,13 @@
+Features
+- Performance improvements — events and transactions now cache locally for faster loading.
+- Copy button for admins to copy the list of members registered for an event.
+- Max event capacity limit for events set to sixty.
+- Handle horizontal rotation on iOS and Android.
+- Added Firebase App Check for improved account security.
+
+Bug Fixes
+- Home view cache refresh fix.
+- Fixed Apple Sign-In authentication errors on iOS and Android.
+- Fixed errors joining a group via an invite link or deep link.
+- Fixed duplicate join-request handling and improved the share/invite flow on web.
+- Clearer error messages and more reliable group creation.


### PR DESCRIPTION
## Summary
Follow-up to #125, which merged before these fixes were pushed. This branch now has everything needed to make `update-ios-metadata.yml` succeed — verified end-to-end against the live App Store Connect app (org.getspot).

Fixes, in the order they were found by iterating against real CI runs:
- Build `api_key` via `app_store_connect_api_key(...)` (matching `promote_build`/`promote_to_review`) instead of relying on implicit `api_key_path` pickup, which never worked.
- Base64-encode the App Store Connect private key before writing it into `.env` — a raw multi-line PEM gets its newlines mangled by GitHub Actions secrets/`.env`, which OpenSSL then rejects as `invalid curve name` ([fastlane/fastlane#29478](https://github.com/fastlane/fastlane/issues/29478)).
- Rotated the App Store Connect API key (old one was rejected as invalid/insufficient permissions) — new Team Key with App Manager role.
- `edit_live: true` (needed since the app has no pending version most of the time) hits a hard fastlane 2.238.0 bug: nil vs Array in `upload_metadata.rb`, unconditional regardless of `skip_app_version_update`. Routed around it by targeting a draft next-version (`app_version: "1.0.4"`, overridable via `app_version:` lane param) instead of editing live — this creates a real, visible draft version in App Store Connect with no binary attached.
- Fixed `fastlane/metadata/en-US/name.txt`: said "GetSpot", but the live app is actually registered as "Sports GetSpot" (plain "GetSpot" is taken by another developer) — pushing the stale name failed outright.
- Disabled `run_precheck_before_submit` — precheck's In-App Purchase check isn't supported with API-key auth, and we don't submit for review here anyway.
- Added `promotional_text.txt` (new marketing copy) and `release_notes.txt` (transcribed from the [1.0.3 GitHub release](https://github.com/amitrke/getspot/releases/tag/1.0.3) as a placeholder until 1.0.4 has a real build/changelog of its own).

## Test plan
- [x] Ran `update-ios-metadata.yml` via `workflow_dispatch` repeatedly against this branch until it succeeded — confirmed `✅ Metadata updated on App Store Connect!`
- [x] Confirmed the privacy policy URL is now `https://www.getspot.org/privacy` on App Store Connect (was the dead `amitrke.github.io/getspot/privacy.html` link — closes #124)
- [ ] After merge, note the draft `1.0.4` version sitting in App Store Connect with no binary — either a real 1.0.4 build should target it eventually, or it can be deleted if not wanted