### PR TITLE
chore: bump app version to 1.0.4+3

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.3+2
+version: 1.0.4+3
 
 environment:
   sdk: ^3.10.0


### PR DESCRIPTION
## Summary
- Bumps `pubspec.yaml` version ahead of any actual new build, so future bugfix/feature branches don't need to remember to do it before pushing.
- 1.0.4 matches the draft version already created in App Store Connect (see #126) — the next real build will attach to that existing draft instead of needing a new version entry.
- Build number continues from +2 to +3 (not reset to +1), since Android's versionCode must strictly increase across all uploads regardless of version name.

## Test plan
- [ ] Next build/release should target 1.0.4 and confirm it attaches to the existing App Store Connect draft version without error